### PR TITLE
feat(frontend): add reusable email verification page and wire signup …

### DIFF
--- a/Documentation/API_routes.md
+++ b/Documentation/API_routes.md
@@ -8,6 +8,8 @@ This document outlines the API routes for the project.
   - [Login: `/auth/login`](#login-authlogin)
   - [Refresh: `/auth/refresh`](#refresh-authrefresh)
   - [Register: `/auth/register`](#register-authregister)
+  - [Send Verification: `/auth/send-verification`](#send-verification-authsend-verification)
+  - [Verify Email: `/auth/verify-email`](#verify-email-authverify-email)
   - [Logout: `/auth/logout`](#logout)
   - [Forgot Password: `/auth/forgot-password`](#forgot-password)
   - [Reset Password: `/auth/reset-password`](#reset-password)
@@ -143,7 +145,7 @@ Request Parameters:
 | email | string | Yes | User email address |
 | password | string | Yes | User password |
 | username | string | Yes | Username |
-| phone_number | string | Yes | User phone number |
+| phone_number | string | No | User phone number |
 
 Request Body:
 ```json
@@ -151,11 +153,11 @@ Request Body:
   "email": "user@example.com", // Required
   "password": "password", // Required
   "username": "user", // Required
-  "phone_number": "1234567890", // Required
+  "phone_number": "1234567890" // Optional
 }
 ```
 
-Response (200 OK):
+Response (201 Created):
 ```json
 {
   "user": {
@@ -163,15 +165,14 @@ Response (200 OK):
     "email": "user@example.com",
     "username": "user"
   },
-  "accessToken": "access_token",
-  "refreshToken": "refresh_token"
+  "message": "Registration successful. Please verify your email."
 }
 ```
 
 Response (400 Bad Request):
 ```json
 {
-  "error": "Invalid input data or invalid invitation token"
+  "error": "Validation failed"
 }
 ```
 
@@ -182,7 +183,93 @@ Response (409 Conflict):
 }
 ```
 
-This endpoint creates a new user account.
+This endpoint creates a new user account and marks it as unverified. It does not issue login tokens.  
+After registration, call `/auth/send-verification` and then `/auth/verify-email` before login.
+
+### Send verification
+
+```
+PUT /auth/send-verification
+```
+
+Request Body:
+```json
+{
+  "email": "user@example.com" // Required
+}
+```
+
+Response (200 OK):
+```json
+{
+  "message": "If the email exists, a verification code was sent."
+}
+```
+
+Response (400 Bad Request):
+```json
+{
+  "errors": [
+    {
+      "msg": "Valid email required"
+    }
+  ]
+}
+```
+
+Notes:
+- This endpoint always returns a generic success message to avoid account enumeration.
+- Resend throttling is enforced internally.
+- Verification state is persisted only after the email provider accepts the send request.
+
+### Verify email
+
+```
+POST /auth/verify-email
+```
+
+Request Body:
+```json
+{
+  "email": "user@example.com", // Required
+  "code": "123456" // Required, 6 digits
+}
+```
+
+Response (200 OK):
+```json
+{
+  "message": "Email verified"
+}
+```
+
+Response (400 Bad Request):
+```json
+{
+  "error": "No verification code found"
+}
+```
+
+Response (400 Bad Request):
+```json
+{
+  "error": "Invalid code"
+}
+```
+
+Response (400 Bad Request):
+```json
+{
+  "error": "Code expired"
+}
+```
+
+Response (429 Too Many Requests):
+```json
+{
+  "error": "Too many attempts"
+}
+```
 
 ### Logout
 
@@ -452,7 +539,7 @@ Response (409 Conflict):
 }
 ```
 
-This endpoint sends a verification code to the new email address. The user must verify this code before the email can be updated.
+This endpoint sends a verification code to the new email address via the email service. The user must verify this code before the email can be updated.
 
 #### Verify and Update Email
 

--- a/Documentation/database_diagram.md
+++ b/Documentation/database_diagram.md
@@ -20,6 +20,14 @@ erDiagram
         TEXT phone_number
         TEXT email UK
     }
+
+    pending_email_changes {
+        INT user_id PK,FK
+        TEXT new_email
+        TEXT verification_code
+        INT expires_at
+        INT created_at
+    }
     
     pod {
         SERIAL pod_id PK
@@ -55,6 +63,7 @@ erDiagram
     }
     
     users ||--|| user_contact : "has"
+    users ||--o| pending_email_changes : "pending email change"
     users ||--o{ user_pod : "belongs to"
     pod ||--o{ user_pod : "contains"
     pod ||--o{ pod_data : "contains"
@@ -65,12 +74,14 @@ erDiagram
 
 ### Relationships
 - **users → user_contact**: One-to-one (one user has one contact entry)
+- **users → pending_email_changes**: One-to-zero/one (temporary pending email change verification state)
 - **users ↔ pod**: Many-to-many (users can belong to multiple pods, pods can have multiple users) via `user_pod` junction table
 - **pod → pod_data**: One-to-many (one pod can have multiple data entries)
 - **pod_data → sensor_data**: One-to-many (one pod_data entry can have multiple sensor readings)
 
 ### Indexes
 - `idx_user_contact_user_id` on `user_contact(user_id)`
+- `idx_pending_email_changes_expires` on `pending_email_changes(expires_at)`
 - `idx_user_pod_user_id` on `user_pod(user_id)`
 - `idx_user_pod_pod_id` on `user_pod(pod_id)`
 - `idx_pod_data_pod_id` on `pod_data(pod_id)`
@@ -83,5 +94,5 @@ erDiagram
 - `users.username` is UNIQUE
 - `user_contact.user_id` is UNIQUE (one-to-one relationship)
 - `user_contact.email` is UNIQUE
+- `pending_email_changes.user_id` is PRIMARY KEY and references `users(user_id)`
 - `user_pod` has a composite primary key on `(user_id, pod_id)`
-

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -8,6 +8,7 @@ import About from "./pages/About";
 import Contact from "./pages/Contact";
 import Profile from "./pages/Profile"
 import Pod from "./pages/Pod";
+import VerifyEmail from "./pages/VerifyEmail";
 
 function App() {
     return (
@@ -19,6 +20,7 @@ function App() {
                     <Route path="/contact" element={<Contact />} />
                     <Route path="/profile" element={<Profile />} />
                     <Route path="/pod/:podId" element={<Pod />} />
+                    <Route path="/verify-email" element={<VerifyEmail />} />
                 </Route>
             </Routes>
         </BrowserRouter>

--- a/frontend/src/components/AuthPanel.tsx
+++ b/frontend/src/components/AuthPanel.tsx
@@ -52,11 +52,17 @@ export default function AuthPanel({
     e.preventDefault();
     if (loading) return;
     setError(null);
+    const normalizedLoginEmail = loginEmail.trim();
     setLoading(true);
     try {
-      const res = await authLogin({ email: loginEmail, password: loginPassword });
+      const res = await authLogin({ email: normalizedLoginEmail, password: loginPassword });
       onAuthSuccess(res.user);
     } catch (err) {
+      if (err instanceof ApiError && err.status === 403) {
+        const next = `/?${new URLSearchParams({ auth: "login", email: normalizedLoginEmail, verified: "1" }).toString()}`;
+        navigate(`/verify-email?${new URLSearchParams({ email: normalizedLoginEmail, next, reason: "login" }).toString()}`);
+        return;
+      }
       if (err instanceof ApiError && err.status === 400) {
         setError(err.message);
       } else {

--- a/frontend/src/components/AuthPanel.tsx
+++ b/frontend/src/components/AuthPanel.tsx
@@ -1,22 +1,30 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
+import { useNavigate } from "react-router-dom";
 import { FiArrowLeft } from "react-icons/fi";
 import type { User } from "../utils/apiTypes";
-import { ApiError, authLogin, authRegister } from "../utils/api";
+import { ApiError, authLogin, authRegister, sendVerification } from "../utils/api";
 import "../styles/AuthPanel.css";
 
 type AuthPanelProps = {
   onAuthSuccess: (user: User) => void;
+  initialMode?: Mode;
+  initialLoginEmail?: string;
 };
 
 type Mode = "login" | "signup";
 
-export default function AuthPanel({ onAuthSuccess }: AuthPanelProps) {
-  const [mode, setMode] = useState<Mode>("login");
+export default function AuthPanel({
+  onAuthSuccess,
+  initialMode = "login",
+  initialLoginEmail = "",
+}: AuthPanelProps) {
+  const navigate = useNavigate();
+  const [mode, setMode] = useState<Mode>(initialMode);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
   // login
-  const [loginEmail, setLoginEmail] = useState("");
+  const [loginEmail, setLoginEmail] = useState(initialLoginEmail);
   const [loginPassword, setLoginPassword] = useState("");
 
   // signup
@@ -25,6 +33,14 @@ export default function AuthPanel({ onAuthSuccess }: AuthPanelProps) {
   const [signupPhone, setSignupPhone] = useState("");
   const [signupPassword, setSignupPassword] = useState("");
   const [signupPasswordRetype, setSignupPasswordRetype] = useState("");
+
+  useEffect(() => {
+    setMode(initialMode);
+  }, [initialMode]);
+
+  useEffect(() => {
+    setLoginEmail(initialLoginEmail);
+  }, [initialLoginEmail]);
 
   function switchMode(next: Mode) {
     setMode(next);
@@ -55,19 +71,39 @@ export default function AuthPanel({ onAuthSuccess }: AuthPanelProps) {
     e.preventDefault();
     if (loading) return;
     setError(null);
+    const normalizedSignupEmail = signupEmail.trim();
     if (signupPassword !== signupPasswordRetype) {
       setError("Passwords do not match.");
       return;
     }
     setLoading(true);
     try {
-      const res = await authRegister({
+      await authRegister({
         username: signupUsername,
-        email: signupEmail,
+        email: normalizedSignupEmail,
         password: signupPassword,
         phone_number: signupPhone.trim(),
       });
-      onAuthSuccess(res.user);
+
+      let verificationSent = true;
+      try {
+        await sendVerification({ email: normalizedSignupEmail });
+      } catch {
+        verificationSent = false;
+      }
+
+      const nextParams = new URLSearchParams({
+        auth: "login",
+        email: normalizedSignupEmail,
+        verified: "1",
+      });
+      const verificationParams = new URLSearchParams({
+        email: normalizedSignupEmail,
+        next: `/?${nextParams.toString()}`,
+        reason: "signup",
+        sent: verificationSent ? "1" : "0",
+      });
+      navigate(`/verify-email?${verificationParams.toString()}`);
     } catch (err) {
       if (err instanceof ApiError && err.status === 400) {
         setError(err.message);
@@ -229,4 +265,3 @@ export default function AuthPanel({ onAuthSuccess }: AuthPanelProps) {
     </div>
   );
 }
-

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from "react";
+import { useSearchParams } from "react-router-dom";
 import MapView from "../components/Map.tsx";
 
 import { getMe, getMeSilent } from "../utils/api.ts";
@@ -8,8 +9,28 @@ import AuthPanel from "../components/AuthPanel.tsx";
 import "../styles/Home.css";
 
 export default function Home() {
+    const [searchParams, setSearchParams] = useSearchParams();
     const [isAuthenticated, setIsAuthenticated] = useState<boolean | null>(null);
     const [user, setUser] = useState<User | null>(null);
+    const [showVerifiedBanner, setShowVerifiedBanner] = useState(false);
+
+    const authParam = searchParams.get("auth");
+    const emailParam = searchParams.get("email") ?? "";
+    const verifiedParam = searchParams.get("verified");
+
+    useEffect(() => {
+        if (verifiedParam !== "1") return;
+        setShowVerifiedBanner(true);
+        const nextParams = new URLSearchParams(searchParams);
+        nextParams.delete("verified");
+        setSearchParams(nextParams, { replace: true });
+    }, [verifiedParam, searchParams, setSearchParams]);
+
+    useEffect(() => {
+        if (isAuthenticated) {
+            setShowVerifiedBanner(false);
+        }
+    }, [isAuthenticated]);
 
     useEffect(() => {
         const ac = new AbortController();
@@ -38,6 +59,15 @@ export default function Home() {
     return (
         <div className="homepage-container">
             <div className={`controls-container ${isAuthenticated === false ? "controls-container--unauthenticated" : ""}`}>
+                {showVerifiedBanner && (
+                    <div className="home-info-banner" role="status">
+                        <p>Email verified. Please log in to continue.</p>
+                        <button type="button" className="home-info-banner-dismiss" onClick={() => setShowVerifiedBanner(false)}>
+                            Dismiss
+                        </button>
+                    </div>
+                )}
+
                 {isAuthenticated && user ? (
                     <>
                         {(user.pods?.length ?? 0) === 0 && (
@@ -55,6 +85,8 @@ export default function Home() {
 
                 {isAuthenticated === false ? (
                     <AuthPanel
+                        initialMode={authParam === "login" ? "login" : undefined}
+                        initialLoginEmail={authParam === "login" ? emailParam : undefined}
                         onAuthSuccess={async () => {
                             try {
                                 const profile = await getMe();

--- a/frontend/src/pages/VerifyEmail.tsx
+++ b/frontend/src/pages/VerifyEmail.tsx
@@ -1,0 +1,182 @@
+import { useEffect, useState } from "react";
+import { Link, useNavigate, useSearchParams } from "react-router-dom";
+import { FiArrowLeft } from "react-icons/fi";
+import { ApiError, sendVerification, verifyEmail } from "../utils/api";
+import "../styles/VerifyEmail.css";
+
+const VERIFICATION_CODE_LENGTH = 6;
+const RESEND_COOLDOWN_SECONDS = 60;
+const EMAIL_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+function getSafeNextPath(rawNext: string | null): string {
+  if (!rawNext) return "/";
+  if (!rawNext.startsWith("/") || rawNext.startsWith("//")) return "/";
+  return rawNext;
+}
+
+function getReasonMessage(reason: string | null): string {
+  if (reason === "signup") {
+    return "Enter the verification code to finish creating your account.";
+  }
+  return "Enter the verification code to continue.";
+}
+
+export default function VerifyEmail() {
+  const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
+
+  const email = (searchParams.get("email") ?? "").trim();
+  const next = getSafeNextPath(searchParams.get("next"));
+  const reason = searchParams.get("reason");
+  const sent = searchParams.get("sent");
+  const hasValidEmail = EMAIL_PATTERN.test(email);
+
+  const [code, setCode] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [resendLoading, setResendLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [info, setInfo] = useState<string | null>(
+    sent === "1"
+      ? `A verification code was sent to ${email}.`
+      : sent === "0"
+        ? "Verification email could not be sent automatically. Use resend to try again."
+        : null,
+  );
+  const [cooldownSeconds, setCooldownSeconds] = useState(sent === "1" ? RESEND_COOLDOWN_SECONDS : 0);
+
+  useEffect(() => {
+    if (cooldownSeconds <= 0) return;
+    const timerId = window.setInterval(() => {
+      setCooldownSeconds((previous) => Math.max(0, previous - 1));
+    }, 1000);
+
+    return () => window.clearInterval(timerId);
+  }, [cooldownSeconds]);
+
+  async function handleVerifySubmit(e: React.FormEvent) {
+    e.preventDefault();
+    if (loading || !hasValidEmail) return;
+
+    const normalizedCode = code.trim();
+    if (normalizedCode.length !== VERIFICATION_CODE_LENGTH) {
+      setError("Please enter a valid 6-digit verification code.");
+      return;
+    }
+
+    setLoading(true);
+    setError(null);
+    setInfo(null);
+
+    try {
+      await verifyEmail({ email, code: normalizedCode });
+      navigate(next, { replace: true });
+    } catch (err) {
+      if (err instanceof ApiError) {
+        setError(err.message);
+      } else {
+        setError("Unable to verify email right now. Please try again.");
+      }
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  async function handleResend() {
+    if (resendLoading || cooldownSeconds > 0 || !hasValidEmail) return;
+
+    setResendLoading(true);
+    setError(null);
+    setInfo(null);
+
+    try {
+      await sendVerification({ email });
+      setInfo(`A new verification code was sent to ${email}.`);
+      setCooldownSeconds(RESEND_COOLDOWN_SECONDS);
+    } catch (err) {
+      if (err instanceof ApiError) {
+        setError(err.message);
+      } else {
+        setError("Unable to resend verification email right now. Please try again.");
+      }
+    } finally {
+      setResendLoading(false);
+    }
+  }
+
+  return (
+    <div className="verify-email-page">
+      <section className="verify-email-card" aria-labelledby="verify-email-title">
+        <Link
+          to="/"
+          style={{
+            alignSelf: "flex-start",
+            color: "#fff",
+            display: "inline-flex",
+            alignItems: "center",
+            gap: "6px",
+            opacity: 0.9,
+          }}
+        >
+          <FiArrowLeft aria-hidden="true" focusable="false" />
+          <span>Back to home</span>
+        </Link>
+        <h1 id="verify-email-title">Verify your email</h1>
+
+        {!hasValidEmail ? (
+          <>
+            <p className="verify-email-copy">
+              This verification link is missing a valid email address. Start again from the previous step.
+            </p>
+            <Link className="btn primary-btn verify-email-home-link" to="/">
+              Return home
+            </Link>
+          </>
+        ) : (
+          <>
+            <p className="verify-email-copy">{getReasonMessage(reason)}</p>
+            <p className="verify-email-address">{email}</p>
+
+            {info && <div className="verify-email-info" role="status">{info}</div>}
+            {error && <div className="verify-email-error" role="alert">{error}</div>}
+
+            <form className="verify-email-form" onSubmit={handleVerifySubmit}>
+              <label className="verify-email-label" htmlFor="verification-code">
+                Verification code
+              </label>
+              <input
+                id="verification-code"
+                className="verify-email-input"
+                type="text"
+                value={code}
+                onChange={(e) => setCode(e.target.value.replace(/\D/g, "").slice(0, VERIFICATION_CODE_LENGTH))}
+                inputMode="numeric"
+                pattern="[0-9]*"
+                maxLength={VERIFICATION_CODE_LENGTH}
+                autoComplete="one-time-code"
+                required
+                disabled={loading}
+              />
+
+              <button className="btn primary-btn verify-email-submit" type="submit" disabled={loading}>
+                {loading ? "Verifying..." : "Verify email"}
+              </button>
+            </form>
+
+            <button
+              className="btn secondary-btn verify-email-resend"
+              type="button"
+              disabled={resendLoading || cooldownSeconds > 0}
+              onClick={handleResend}
+            >
+              {resendLoading
+                ? "Resending..."
+                : cooldownSeconds > 0
+                  ? `Resend code (${cooldownSeconds}s)`
+                  : "Resend code"}
+            </button>
+          </>
+        )}
+      </section>
+    </div>
+  );
+}

--- a/frontend/src/styles/Home.css
+++ b/frontend/src/styles/Home.css
@@ -22,3 +22,34 @@
 .controls-container .btn {
     width: 100%;
 }
+
+.home-info-banner {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+    margin-bottom: 16px;
+    padding: 12px;
+    border-radius: 10px;
+    background: rgba(48, 164, 108, 0.2);
+    border: 1px solid rgba(48, 164, 108, 0.6);
+}
+
+.home-info-banner p {
+    margin: 0;
+    font-weight: 600;
+}
+
+.home-info-banner-dismiss {
+    border: 1px solid rgba(255, 255, 255, 0.35);
+    border-radius: 8px;
+    background: transparent;
+    color: #fff;
+    cursor: pointer;
+    padding: 6px 10px;
+    white-space: nowrap;
+}
+
+.home-info-banner-dismiss:hover {
+    background: rgba(255, 255, 255, 0.1);
+}

--- a/frontend/src/styles/VerifyEmail.css
+++ b/frontend/src/styles/VerifyEmail.css
@@ -1,0 +1,88 @@
+.verify-email-page {
+  display: flex;
+  justify-content: center;
+  padding: 40px 16px;
+}
+
+.verify-email-card {
+  width: min(520px, 100%);
+  background: var(--secondary-green);
+  border-radius: 16px;
+  padding: 24px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.verify-email-card h1 {
+  margin: 0;
+}
+
+.verify-email-copy {
+  margin: 0;
+  opacity: 0.95;
+}
+
+.verify-email-address {
+  margin: 0;
+  font-weight: 700;
+}
+
+.verify-email-form {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.verify-email-label {
+  font-weight: 600;
+}
+
+.verify-email-input {
+  border-radius: 10px;
+  border: 1px solid rgba(255, 255, 255, 0.25);
+  padding: 10px 12px;
+  background: rgba(0, 0, 0, 0.15);
+  color: white;
+  outline: none;
+}
+
+.verify-email-submit,
+.verify-email-resend,
+.verify-email-home-link {
+  width: 100%;
+  margin-bottom: 0;
+}
+
+.verify-email-home-text {
+  align-self: center;
+  font-size: 0.95rem;
+  opacity: 0.7;
+  color: #fff;
+}
+
+/* .verify-email-home-text::before {
+  content: "\2190 ";
+} */
+
+.verify-email-home-text:hover {
+  opacity: 1;
+}
+
+.verify-email-info,
+.verify-email-error {
+  border-radius: 10px;
+  padding: 10px 12px;
+  font-weight: 600;
+}
+
+.verify-email-info {
+  background: rgba(48, 164, 108, 0.18);
+  border: 1px solid rgba(48, 164, 108, 0.6);
+}
+
+.verify-email-error {
+  background: rgba(255, 118, 101, 0.15);
+  border: 1px solid rgba(255, 118, 101, 0.5);
+  color: var(--warning-red);
+}

--- a/frontend/src/utils/api.ts
+++ b/frontend/src/utils/api.ts
@@ -331,15 +331,13 @@ export async function authRefresh(payload: AuthRefreshRequest, signal?: AbortSig
 }
 
 export async function authRegister(payload: AuthRegisterRequest, signal?: AbortSignal): Promise<AuthRegisterResponse> {
-  const res = await request<AuthRegisterResponse>({
+  return await request<AuthRegisterResponse>({
     method: "POST",
     path: "/auth/register",
     body: payload,
     auth: false,
     signal,
   });
-  setTokens(res);
-  return res;
 }
 
 export async function authLogout(

--- a/frontend/src/utils/apiTypes.ts
+++ b/frontend/src/utils/apiTypes.ts
@@ -84,7 +84,7 @@ export type AuthRefreshRequest = { refreshToken: string };
 export type AuthRefreshResponse = { accessToken: string; refreshToken: string };
 
 export type AuthRegisterRequest = { email: string; password: string; username: string; phone_number: string };
-export type AuthRegisterResponse = { user: User; accessToken: string; refreshToken: string };
+export type AuthRegisterResponse = { user: User; message: string };
 
 export type AuthLogoutRequest = { refreshToken: string };
 export type AuthForgotPasswordRequest = { email: string };
@@ -151,5 +151,4 @@ export type UploadPodDataResponse = MessageResponse & { podDataId: string };
 
 export type DeletePodDataRequest = { podDataId: string };
 export type DeletePodDataResponse = MessageResponse & { podDataId: string };
-
 


### PR DESCRIPTION
## Summary
This PR adds a reusable frontend email-verification step and hooks it into the signup pipeline.

After signup, users are sent to `/verify-email` where they can submit a verification code or resend one. On successful verification, they are redirected to home with login prefilled.

## What Changed

### Routing / Pages
- Added `VerifyEmail` page:
  - `frontend/src/pages/VerifyEmail.tsx`
  - `frontend/src/styles/VerifyEmail.css`
- Added route:
  - `"/verify-email"` in `frontend/src/App.tsx`

### Signup Integration
- Updated `AuthPanel` signup flow:
  - Calls `authRegister(...)`
  - Attempts `sendVerification({ email })` (non-fatal on failure)
  - Navigates to:
    - `/verify-email?email=<email>&next=<encoded-path>&reason=signup&sent=<0|1>`
- Login behavior remains unchanged (`onAuthSuccess` still only used for login).

### Reusable AuthPanel Inputs
- Extended `AuthPanel` props:
  - `initialMode?: "login" | "signup"`
  - `initialLoginEmail?: string`

### Home Page Handoff / UX
- `Home` now reads query params (`auth`, `email`, `verified`) and:
  - Prefills login email when redirected from verification
  - Shows one-time “Email verified” info banner
  - Removes `verified` query param after showing banner
  - Auto-dismisses banner once user logs in

### API Type / Behavior Fix
- Updated `AuthRegisterResponse` type to match backend response:
  - `{ user: User; message: string }`
- Removed token persistence from `authRegister` (register does not return auth tokens).

<img width="638" height="520" alt="Screenshot 2026-03-02 at 1 29 22 pm" src="https://github.com/user-attachments/assets/27d5b249-d548-47a8-813a-95c1790d007a" />

<img width="605" height="494" alt="Screenshot 2026-03-02 at 1 31 14 pm" src="https://github.com/user-attachments/assets/da90d1c6-dd53-4699-8c16-53d67154ea68" />
