### PR TITLE
Feat/share pods

### DIFF
--- a/Documentation/API_routes.md
+++ b/Documentation/API_routes.md
@@ -933,7 +933,8 @@ Response (200 OK):
       "latitude": 123.456,
       "longitude": 123.456,
       "visibility": "public", // "public" or "private"
-      "lastUpdated": "2021-01-01T00:00:00.000Z"
+      "lastUpdated": "2021-01-01T00:00:00.000Z",
+      "isOwner": true // true if authenticated user owns this pod, false otherwise
     }
   ]
 }

--- a/Documentation/API_routes.md
+++ b/Documentation/API_routes.md
@@ -35,6 +35,7 @@ This document outlines the API routes for the project.
   - [Get Pod Locations: `/pods/locations`](#get-pod-locations)
   - [Get Pod Data: `/pods/{id}/data`](#get-pod-data)
   - [Upload Pod Data: `/pods/upload-pod-data`](#upload-pod-data)
+  - [Add Pod Owner: `/pods/{id}/owners`](#add-pod-owner)
   - [Delete Pod Data: `/pods/delete-pod-data`](#delete-pod-data)
 ## Authentication
 
@@ -412,17 +413,24 @@ Response (200 OK):
 ```json
 {
   "user": {
-    "id": "123",
+    "id": 123,
     "email": "user@example.com",
     "phone_number": "1234567890",
     "username": "user",
-    "pods": ["pod_id_1", "pod_id_2"], // Array of pod IDs
-    "podData": ["pod_data_id_1", "pod_data_id_2"] // Array of pod data IDs
+    "pods": [
+      {
+        "id": 1,
+        "name": "My Pod",
+        "visibility": true,
+        "lat": "40.014",
+        "long": "-105.270"
+      }
+    ]
   }
 }
 ```
 
-This endpoint returns the current user's information.
+This endpoint returns the current user's information including their registered pods.
 
 ### Search Users by Username
 
@@ -1003,30 +1011,32 @@ This endpoint returns all pod names and their locations. Will return all pods if
 GET /pods/{id}/data
 ```
 
+Authentication:
+- Optional. Public pods are accessible anonymously. Private pods require the requesting user to be the owner or an admin.
+
 Response (200 OK):
 ```json
 {
   "id": "123",
   "nickname": "nickname",
-  "latitude": 123.456,
-  "longitude": 123.456,
-  "visibility": "public", // "public" or "private"
+  "latitude": 40.014,
+  "longitude": -105.270,
+  "visibility": "public",
   "lastUpdated": "2021-01-01T00:00:00.000Z",
   "data": [
     {
-      "id": "123",
+      "id": "456",
       "timestamp": "2021-01-01T00:00:00.000Z",
       "data": {
-        "sensor_data_id": "123",
-        "pod_data_id": "pod_data_id_1",
         "sensor_type": "temperature",
         "reading_value": 23.5,
         "reading_units": "C",
-        "reading_timestamp": "2021-01-01T00:00:00.000Z",
-        "raw_data": {}, // JSONB raw sensor payload
-        "created_at": "2021-01-01T00:00:00.000Z"
+        "location": {
+          "latitude": 40.014,
+          "longitude": -105.270
+        }
       },
-      "visibility": "public" // "public" or "private"
+      "visibility": "public"
     }
   ],
   "viewer": {
@@ -1038,6 +1048,13 @@ Response (200 OK):
 }
 ```
 
+Response (403 Forbidden):
+```json
+{
+  "error": "Forbidden"
+}
+```
+
 Response (404 Not Found):
 ```json
 {
@@ -1045,9 +1062,7 @@ Response (404 Not Found):
 }
 ```
 
-This endpoint returns all recorded data for a specific pod sorted by timestamp in descending order. Only accessible if pod is public or the user is the owner of the pod.
-
-TODO: Location history of pod.
+This endpoint returns all recorded sensor data for a specific pod. The `viewer` object indicates the requesting user's permissions. Pod metadata (`id`, `nickname`, `latitude`, `longitude`, `visibility`, `lastUpdated`) is derived from the pod record and the most recent `pod_data` row.
 
 ### Upload Pod Data
 
@@ -1102,6 +1117,77 @@ Response (403 Forbidden):
 ```
 
 This endpoint uploads pod data to the database.
+
+### Add Pod Owner
+
+```
+POST /pods/{id}/owners
+```
+
+Authentication:
+- Bearer token required. The requesting user must own the pod or be an admin.
+
+Request Parameters:
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| id | integer | Yes | Pod ID (URL parameter, positive integer) |
+| userId | integer | Yes | ID of the user to add as an owner (positive integer) |
+
+Request Body:
+```json
+{
+  "userId": 42
+}
+```
+
+Response (201 Created):
+```json
+{
+  "message": "Pod owner added successfully",
+  "podId": "123",
+  "userId": "42"
+}
+```
+
+Response (400 Bad Request):
+```json
+{
+  "error": "Validation failed",
+  "details": [
+    { "field": "userId", "message": "userId must be a positive integer" }
+  ]
+}
+```
+
+Response (403 Forbidden):
+```json
+{
+  "error": "Forbidden"
+}
+```
+
+Response (404 Not Found):
+```json
+{
+  "error": "Pod not found"
+}
+```
+
+```json
+{
+  "error": "User not found"
+}
+```
+
+Response (409 Conflict):
+```json
+{
+  "error": "User is already an owner of this pod"
+}
+```
+
+This endpoint adds a user as a co-owner of a pod. The requesting user must already own the pod (or be an admin). The target user is looked up by `userId` — use `GET /users/search` to find users by username.
 
 ### Delete Pod Data
 

--- a/Documentation/API_routes.md
+++ b/Documentation/API_routes.md
@@ -36,6 +36,7 @@ This document outlines the API routes for the project.
   - [Get Pod Data: `/pods/{id}/data`](#get-pod-data)
   - [Upload Pod Data: `/pods/upload-pod-data`](#upload-pod-data)
   - [Add Pod Owner: `/pods/{id}/owners`](#add-pod-owner)
+  - [Get Pod Owners: `/pods/{id}/owners`](#get-pod-owners)
   - [Delete Pod Data: `/pods/delete-pod-data`](#delete-pod-data)
 ## Authentication
 
@@ -1188,6 +1189,62 @@ Response (409 Conflict):
 ```
 
 This endpoint adds a user as a co-owner of a pod. The requesting user must already own the pod (or be an admin). The target user is looked up by `userId` — use `GET /users/search` to find users by username.
+
+### Get Pod Owners
+
+```
+GET /pods/{id}/owners
+```
+
+Authentication:
+- Bearer token required. The requesting user must own the pod or be an admin.
+
+Request Parameters:
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| id | integer | Yes | Pod ID (URL parameter, positive integer) |
+
+Example Request:
+```
+GET /pods/123/owners
+```
+
+Response (200 OK):
+```json
+{
+  "owners": [
+    { "id": 1, "username": "alice" },
+    { "id": 42, "username": "bob" }
+  ]
+}
+```
+
+Response (400 Bad Request):
+```json
+{
+  "error": "Validation failed",
+  "details": [
+    { "field": "id", "message": "Pod id must be a positive integer" }
+  ]
+}
+```
+
+Response (403 Forbidden):
+```json
+{
+  "error": "Forbidden"
+}
+```
+
+Response (404 Not Found):
+```json
+{
+  "error": "Pod not found"
+}
+```
+
+This endpoint returns all owners of a pod. The requesting user must be an owner of the pod or an admin. Owners are returned sorted alphabetically by username.
 
 ### Delete Pod Data
 

--- a/Documentation/API_routes.md
+++ b/Documentation/API_routes.md
@@ -979,7 +979,13 @@ Response (200 OK):
       },
       "visibility": "public" // "public" or "private"
     }
-  ]
+  ],
+  "viewer": {
+    "isAuthenticated": true,
+    "isOwner": true,
+    "isAdmin": false,
+    "canManagePod": true
+  }
 }
 ```
 

--- a/backend/API/pod.js
+++ b/backend/API/pod.js
@@ -416,6 +416,67 @@ module.exports = (db) => {
     );
 
     // -------------------------
+    // GET /pods/:id/owners
+    // -------------------------
+    // Get all owners of a pod (owner or admin required)
+    router.get("/:id/owners",
+        authenticateToken,
+        [param("id").isInt({ gt: 0 }).withMessage("Pod id must be a positive integer")],
+        async (req, res) => {
+            try {
+                const errors = validationResult(req);
+                if (!errors.isEmpty()) {
+                    return res.status(400).json({
+                        error: "Validation failed",
+                        details: errors.array().map((err) => ({
+                            field: err.param,
+                            message: err.msg,
+                        })),
+                    });
+                }
+
+                const podId = Number(req.params.id);
+                const userId = req.user.id;
+
+                const pod = await getPodById(db, podId);
+                if (!pod) return res.status(404).json({ error: "Pod not found" });
+
+                const isAdmin = await getIsAdmin(userId);
+                const isOwner = await userOwnsPod(db, userId, podId);
+
+                if (!isOwner && !isAdmin) {
+                    return res.status(403).json({ error: "Forbidden" });
+                }
+
+                const owners = await db.all(
+                    `
+                    SELECT u.user_id, u.username
+                    FROM users u
+                    JOIN user_pod up ON u.user_id = up.user_id
+                    WHERE up.pod_id = ?
+                    ORDER BY LOWER(u.username) ASC
+                    `,
+                    [podId]
+                );
+
+                return res.status(200).json({
+                    owners: owners.map((owner) => ({
+                        id: owner.user_id,
+                        username: owner.username,
+                    })),
+                });
+            } catch (error) {
+                return res.status(500).json({
+                    error: "Internal server error",
+                    where: "/pods/:id/owners",
+                    message: error?.message,
+                    code: error?.code,
+                });
+            }
+        }
+    );
+
+    // -------------------------
     // POST /pods/upload-pod-data
     // -------------------------
     router.post("/upload-pod-data",

--- a/backend/API/pod.js
+++ b/backend/API/pod.js
@@ -311,6 +311,86 @@ module.exports = (db) => {
     );
 
     // -------------------------
+    // POST /pods/:id/owners
+    // -------------------------
+    // owner (or admin) can add another user as a pod owner
+    router.post("/:id/owners",
+        authenticateToken,
+        sanitizeRequestBody,
+        [
+            param("id").isInt({ gt: 0 }).withMessage("Pod id must be a positive integer"),
+            body("userId").isInt({ gt: 0 }).withMessage("userId must be a positive integer"),
+        ],
+        async (req, res) => {
+            try {
+                const errors = validationResult(req);
+                if (!errors.isEmpty()) {
+                    return res.status(400).json({
+                        error: "Validation failed",
+                        details: errors.array().map((err) => ({
+                            field: err.param,
+                            message: err.msg,
+                        })),
+                    });
+                }
+
+                const podId = Number(req.params.id);
+                const targetUserId = Number(req.body.userId);
+                const requestingUserId = req.user.id;
+
+                const pod = await getPodById(db, podId);
+                if (!pod) return res.status(404).json({ error: "Pod not found" });
+
+                const isAdmin = await getIsAdmin(requestingUserId);
+                const requesterOwnsPod = await userOwnsPod(db, requestingUserId, podId);
+
+                if (!requesterOwnsPod && !isAdmin) {
+                    return res.status(403).json({ error: "Forbidden" });
+                }
+
+                const targetUser = await db.get(
+                    `
+                    SELECT user_id
+                    FROM users
+                    WHERE user_id = ?
+                    `,
+                    [targetUserId]
+                );
+
+                if (!targetUser) {
+                    return res.status(404).json({ error: "User not found" });
+                }
+
+                const targetAlreadyOwnsPod = await userOwnsPod(db, targetUserId, podId);
+                if (targetAlreadyOwnsPod) {
+                    return res.status(409).json({ error: "User is already an owner of this pod" });
+                }
+
+                await db.run(
+                    `
+                    INSERT INTO user_pod (user_id, pod_id)
+                    VALUES (?, ?)
+                    `,
+                    [targetUserId, podId]
+                );
+
+                return res.status(201).json({
+                    message: "Pod owner added successfully",
+                    podId: String(podId),
+                    userId: String(targetUserId),
+                });
+            } catch (error) {
+                return res.status(500).json({
+                    error: "Internal server error",
+                    where: "/pods/:id/owners",
+                    message: error?.message,
+                    code: error?.code,
+                });
+            }
+        }
+    );
+
+    // -------------------------
     // POST /pods/upload-pod-data
     // -------------------------
     router.post("/upload-pod-data",

--- a/backend/API/pod.js
+++ b/backend/API/pod.js
@@ -290,7 +290,15 @@ module.exports = (db) => {
                 }
 
 
-                return res.status(200).json({ data });
+                return res.status(200).json({
+                    data,
+                    viewer: {
+                        isAuthenticated: !!userId,
+                        isOwner: owns,
+                        isAdmin,
+                        canManagePod: owns || isAdmin,
+                    },
+                });
             } catch (error) {
                 return res.status(500).json({
                     error: "Internal server error",

--- a/backend/API/pod.js
+++ b/backend/API/pod.js
@@ -305,7 +305,17 @@ module.exports = (db) => {
                 }
 
 
+                const latestPodData = podDataRows.length > 0 ? podDataRows[0] : null;
+
                 return res.status(200).json({
+                    id: String(pod.pod_id),
+                    nickname: pod.pod_name ?? null,
+                    latitude: latestPodData ? Number(latestPodData.latitude) : null,
+                    longitude: latestPodData ? Number(latestPodData.longitude) : null,
+                    visibility: isPublic ? "public" : "private",
+                    lastUpdated: latestPodData?.created_at
+                        ? new Date(latestPodData.created_at).toISOString()
+                        : null,
                     data,
                     viewer: {
                         isAuthenticated: !!userId,

--- a/backend/API/pod.js
+++ b/backend/API/pod.js
@@ -218,7 +218,22 @@ module.exports = (db) => {
                     })
                     .filter(Boolean);
 
-                return res.status(200).json({ pods });
+                let ownedPodIds = new Set();
+                if (userId && pods.length > 0) {
+                    const placeholders = pods.map(() => "?").join(",");
+                    const ownedRows = await db.all(
+                        `SELECT pod_id FROM user_pod WHERE user_id = ? AND pod_id IN (${placeholders})`,
+                        [userId, ...pods.map((p) => p.id)]
+                    );
+                    ownedPodIds = new Set(ownedRows.map((r) => String(r.pod_id)));
+                }
+
+                const podsWithOwnership = pods.map((p) => ({
+                    ...p,
+                    isOwner: ownedPodIds.has(p.id),
+                }));
+
+                return res.status(200).json({ pods: podsWithOwnership });
             } catch (error) {
                 return res.status(500).json({
                     error: "Internal server error",

--- a/backend/API/user.js
+++ b/backend/API/user.js
@@ -113,6 +113,8 @@ module.exports = (db) => {
                 SELECT u.user_id, u.username
                 FROM users u
                 WHERE LOWER(u.username) LIKE ? ESCAPE '\\'
+                AND u.admin = 0
+                AND u.user_id != ?
                 ORDER BY
                     CASE
                         WHEN LOWER(u.username) = ? THEN 0
@@ -122,7 +124,7 @@ module.exports = (db) => {
                     LOWER(u.username) ASC
                 LIMIT ?
                 `,
-                [containsPattern, searchTerm, prefixPattern, limit]
+                [containsPattern, req.user.id, searchTerm, prefixPattern, limit]
             );
 
             return res.status(200).json({

--- a/backend/test/API/pod.test.mjs
+++ b/backend/test/API/pod.test.mjs
@@ -10,6 +10,7 @@ describe("Pod API Tests", function () {
 
   let accessTokenUser;
   let accessTokenAdmin;
+  let accessTokenCollaborator;
   let userId;
   let adminId;
   let collaboratorId;
@@ -22,7 +23,6 @@ describe("Pod API Tests", function () {
     db = await createTestDb();
     app = makeTestApp(db);
 
-    // normal user
     const userHash = await bcrypt.hash("Password1", 12);
     const userInsert = await db.run(
       "INSERT INTO users (username, password_hash, admin) VALUES (?, ?, ?)",
@@ -35,7 +35,6 @@ describe("Pod API Tests", function () {
       [userId, "Test User", userEmail]
     );
 
-    // admin user
     const adminHash = await bcrypt.hash("Password1", 12);
     const adminInsert = await db.run(
       "INSERT INTO users (username, password_hash, admin) VALUES (?, ?, ?)",
@@ -48,7 +47,6 @@ describe("Pod API Tests", function () {
       [adminId, "Admin User", adminEmail]
     );
 
-    // collaborator user
     const collaboratorHash = await bcrypt.hash("Password1", 12);
     const collaboratorInsert = await db.run(
       "INSERT INTO users (username, password_hash, admin) VALUES (?, ?, ?)",
@@ -61,19 +59,23 @@ describe("Pod API Tests", function () {
       [collaboratorId, "Collaborator User", collaboratorEmail]
     );
 
-    // login user
     const loginUserRes = await request(app).post("/api/auth/login").send({
       email: userEmail,
       password: "Password1",
     });
     accessTokenUser = loginUserRes.body.accessToken;
 
-    // login admin
     const loginAdminRes = await request(app).post("/api/auth/login").send({
       email: adminEmail,
       password: "Password1",
     });
     accessTokenAdmin = loginAdminRes.body.accessToken;
+
+    const loginCollaboratorRes = await request(app).post("/api/auth/login").send({
+      email: collaboratorEmail,
+      password: "Password1",
+    });
+    accessTokenCollaborator = loginCollaboratorRes.body.accessToken;
   });
 
   afterEach(async () => {
@@ -341,6 +343,206 @@ describe("Pod API Tests", function () {
   });
 
   // -------------------------
+  // GET /api/pods/:id/owners
+  // -------------------------
+  describe("GET /api/pods/:id/owners", () => {
+    it("should allow a pod owner to retrieve owners list", async () => {
+      const podRes = await db.run(
+        "INSERT INTO pod (pod_name, pod_data_public) VALUES (?, ?)",
+        ["OwnedPod", 0]
+      );
+
+      await db.run("INSERT INTO user_pod (user_id, pod_id) VALUES (?, ?)", [
+        userId,
+        podRes.lastID,
+      ]);
+
+      const res = await request(app)
+        .get(`/api/pods/${podRes.lastID}/owners`)
+        .set("Authorization", `Bearer ${accessTokenUser}`);
+
+      expect(res.status).to.equal(200);
+      expect(res.body).to.have.property("owners");
+      expect(res.body.owners).to.be.an("array");
+      expect(res.body.owners.length).to.equal(1);
+      expect(res.body.owners[0]).to.have.property("id");
+      expect(res.body.owners[0]).to.have.property("username");
+      expect(res.body.owners[0].id).to.equal(userId);
+      expect(res.body.owners[0].username).to.equal("TestUser1");
+    });
+
+    it("should allow an admin to retrieve owners list even if not owner", async () => {
+      const podRes = await db.run(
+        "INSERT INTO pod (pod_name, pod_data_public) VALUES (?, ?)",
+        ["PrivatePod", 0]
+      );
+
+      await db.run("INSERT INTO user_pod (user_id, pod_id) VALUES (?, ?)", [
+        userId,
+        podRes.lastID,
+      ]);
+
+      const res = await request(app)
+        .get(`/api/pods/${podRes.lastID}/owners`)
+        .set("Authorization", `Bearer ${accessTokenAdmin}`);
+
+      expect(res.status).to.equal(200);
+      expect(res.body.owners.length).to.equal(1);
+    });
+
+    it("should return 403 when collaborator (non-owner) tries to access owners", async () => {
+      const podRes = await db.run(
+        "INSERT INTO pod (pod_name, pod_data_public) VALUES (?, ?)",
+        ["PrivatePod", 0]
+      );
+
+      await db.run("INSERT INTO user_pod (user_id, pod_id) VALUES (?, ?)", [
+        userId,
+        podRes.lastID,
+      ]);
+
+      const res = await request(app)
+        .get(`/api/pods/${podRes.lastID}/owners`)
+        .set("Authorization", `Bearer ${accessTokenCollaborator}`);
+
+      expect(res.status).to.equal(403);
+      expect(res.body).to.have.property("error");
+      expect(res.body.error).to.equal("Forbidden");
+    });
+
+    it("should return 401 when unauthenticated", async () => {
+      const podRes = await db.run(
+        "INSERT INTO pod (pod_name, pod_data_public) VALUES (?, ?)",
+        ["PrivatePod", 0]
+      );
+
+      const res = await request(app).get(`/api/pods/${podRes.lastID}/owners`);
+
+      expect(res.status).to.equal(401);
+    });
+
+    it("should return 404 when pod does not exist", async () => {
+      const res = await request(app)
+        .get("/api/pods/99999/owners")
+        .set("Authorization", `Bearer ${accessTokenUser}`);
+
+      expect(res.status).to.equal(404);
+      expect(res.body).to.have.property("error");
+      expect(res.body.error).to.equal("Pod not found");
+    });
+
+    it("should return 400 when pod_id is invalid (zero)", async () => {
+      const res = await request(app)
+        .get("/api/pods/0/owners")
+        .set("Authorization", `Bearer ${accessTokenUser}`);
+
+      expect(res.status).to.equal(400);
+      expect(res.body).to.have.property("error");
+      expect(res.body.error).to.equal("Validation failed");
+    });
+
+    it("should return 400 when pod_id is invalid (negative)", async () => {
+      const res = await request(app)
+        .get("/api/pods/-5/owners")
+        .set("Authorization", `Bearer ${accessTokenUser}`);
+
+      expect(res.status).to.equal(400);
+      expect(res.body).to.have.property("error");
+      expect(res.body.error).to.equal("Validation failed");
+    });
+
+    it("should return 400 when pod_id is invalid (string)", async () => {
+      const res = await request(app)
+        .get("/api/pods/abc/owners")
+        .set("Authorization", `Bearer ${accessTokenUser}`);
+
+      expect(res.status).to.equal(400);
+      expect(res.body).to.have.property("error");
+      expect(res.body.error).to.equal("Validation failed");
+    });
+
+    it("should return owners sorted alphabetically by username", async () => {
+      const podRes = await db.run(
+        "INSERT INTO pod (pod_name, pod_data_public) VALUES (?, ?)",
+        ["MultiOwnerPod", 0]
+      );
+
+      const zebraHash = await bcrypt.hash("Password1", 12);
+      const zebraInsert = await db.run(
+        "INSERT INTO users (username, password_hash, admin) VALUES (?, ?, ?)",
+        ["ZebraUser", zebraHash, 0]
+      );
+
+      const alphaHash = await bcrypt.hash("Password1", 12);
+      const alphaInsert = await db.run(
+        "INSERT INTO users (username, password_hash, admin) VALUES (?, ?, ?)",
+        ["AlphaUser", alphaHash, 0]
+      );
+
+      await db.run("INSERT INTO user_pod (user_id, pod_id) VALUES (?, ?)", [
+        userId,
+        podRes.lastID,
+      ]);
+      await db.run("INSERT INTO user_pod (user_id, pod_id) VALUES (?, ?)", [
+        zebraInsert.lastID,
+        podRes.lastID,
+      ]);
+      await db.run("INSERT INTO user_pod (user_id, pod_id) VALUES (?, ?)", [
+        alphaInsert.lastID,
+        podRes.lastID,
+      ]);
+
+      const res = await request(app)
+        .get(`/api/pods/${podRes.lastID}/owners`)
+        .set("Authorization", `Bearer ${accessTokenUser}`);
+
+      expect(res.status).to.equal(200);
+      expect(res.body.owners.length).to.equal(3);
+      expect(res.body.owners[0].username).to.equal("AlphaUser");
+      expect(res.body.owners[1].username).to.equal("TestUser1");
+      expect(res.body.owners[2].username).to.equal("ZebraUser");
+    });
+
+    it("should return empty array when pod has no owners (edge case)", async () => {
+      const podRes = await db.run(
+        "INSERT INTO pod (pod_name, pod_data_public) VALUES (?, ?)",
+        ["OrphanPod", 0]
+      );
+
+      await db.run("INSERT INTO user_pod (user_id, pod_id) VALUES (?, ?)", [
+        adminId,
+        podRes.lastID,
+      ]);
+
+      const res = await request(app)
+        .get(`/api/pods/${podRes.lastID}/owners`)
+        .set("Authorization", `Bearer ${accessTokenAdmin}`);
+
+      expect(res.status).to.equal(200);
+      expect(res.body.owners.length).to.equal(1);
+    });
+
+    it("should return correct fields in response (id and username only)", async () => {
+      const podRes = await db.run(
+        "INSERT INTO pod (pod_name, pod_data_public) VALUES (?, ?)",
+        ["OwnedPod", 0]
+      );
+
+      await db.run("INSERT INTO user_pod (user_id, pod_id) VALUES (?, ?)", [
+        userId,
+        podRes.lastID,
+      ]);
+
+      const res = await request(app)
+        .get(`/api/pods/${podRes.lastID}/owners`)
+        .set("Authorization", `Bearer ${accessTokenUser}`);
+
+      expect(res.status).to.equal(200);
+      expect(res.body.owners[0]).to.have.keys(["id", "username"]);
+    });
+  });
+
+  // -------------------------
   // POST /api/pods/:id/owners
   // -------------------------
   describe("POST /api/pods/:id/owners", () => {
@@ -369,6 +571,31 @@ describe("Pod API Tests", function () {
       expect(ownerRow).to.not.equal(undefined);
     });
 
+    it("should allow an admin to add owner even if not owner of pod", async () => {
+      const podRes = await db.run(
+        "INSERT INTO pod (pod_name, pod_data_public) VALUES (?, ?)",
+        ["AdminPod", 0]
+      );
+
+      await db.run("INSERT INTO user_pod (user_id, pod_id) VALUES (?, ?)", [
+        userId,
+        podRes.lastID,
+      ]);
+
+      const res = await request(app)
+        .post(`/api/pods/${podRes.lastID}/owners`)
+        .set("Authorization", `Bearer ${accessTokenAdmin}`)
+        .send({ userId: collaboratorId });
+
+      expect(res.status).to.equal(201);
+
+      const ownerRow = await db.get(
+        "SELECT 1 FROM user_pod WHERE user_id = ? AND pod_id = ?",
+        [collaboratorId, podRes.lastID]
+      );
+      expect(ownerRow).to.not.equal(undefined);
+    });
+
     it("should reject adding an owner when requester does not own pod", async () => {
       const podRes = await db.run(
         "INSERT INTO pod (pod_name, pod_data_public) VALUES (?, ?)",
@@ -381,6 +608,19 @@ describe("Pod API Tests", function () {
         .send({ userId: collaboratorId });
 
       expect(res.status).to.equal(403);
+    });
+
+    it("should return 401 when unauthenticated", async () => {
+      const podRes = await db.run(
+        "INSERT INTO pod (pod_name, pod_data_public) VALUES (?, ?)",
+        ["PrivatePod", 0]
+      );
+
+      const res = await request(app)
+        .post(`/api/pods/${podRes.lastID}/owners`)
+        .send({ userId: collaboratorId });
+
+      expect(res.status).to.equal(401);
     });
 
     it("should return 404 when target user does not exist", async () => {
@@ -400,6 +640,8 @@ describe("Pod API Tests", function () {
         .send({ userId: 99999 });
 
       expect(res.status).to.equal(404);
+      expect(res.body).to.have.property("error");
+      expect(res.body.error).to.equal("User not found");
     });
 
     it("should return 409 when target user is already an owner", async () => {
@@ -423,6 +665,197 @@ describe("Pod API Tests", function () {
         .send({ userId: collaboratorId });
 
       expect(res.status).to.equal(409);
+      expect(res.body).to.have.property("error");
+      expect(res.body.error).to.equal("User is already an owner of this pod");
+    });
+
+    it("should return 404 when pod does not exist", async () => {
+      const res = await request(app)
+        .post("/api/pods/99999/owners")
+        .set("Authorization", `Bearer ${accessTokenUser}`)
+        .send({ userId: collaboratorId });
+
+      expect(res.status).to.equal(404);
+      expect(res.body).to.have.property("error");
+      expect(res.body.error).to.equal("Pod not found");
+    });
+
+    it("should return 400 when pod_id is invalid (zero)", async () => {
+      const res = await request(app)
+        .post("/api/pods/0/owners")
+        .set("Authorization", `Bearer ${accessTokenUser}`)
+        .send({ userId: collaboratorId });
+
+      expect(res.status).to.equal(400);
+      expect(res.body).to.have.property("error");
+      expect(res.body.error).to.equal("Validation failed");
+    });
+
+    it("should return 400 when pod_id is invalid (negative)", async () => {
+      const res = await request(app)
+        .post("/api/pods/-5/owners")
+        .set("Authorization", `Bearer ${accessTokenUser}`)
+        .send({ userId: collaboratorId });
+
+      expect(res.status).to.equal(400);
+      expect(res.body).to.have.property("error");
+      expect(res.body.error).to.equal("Validation failed");
+    });
+
+    it("should return 400 when pod_id is invalid (string)", async () => {
+      const res = await request(app)
+        .post("/api/pods/abc/owners")
+        .set("Authorization", `Bearer ${accessTokenUser}`)
+        .send({ userId: collaboratorId });
+
+      expect(res.status).to.equal(400);
+      expect(res.body).to.have.property("error");
+      expect(res.body.error).to.equal("Validation failed");
+    });
+
+    it("should return 400 when userId is invalid (zero)", async () => {
+      const podRes = await db.run(
+        "INSERT INTO pod (pod_name, pod_data_public) VALUES (?, ?)",
+        ["OwnedPod", 0]
+      );
+
+      await db.run("INSERT INTO user_pod (user_id, pod_id) VALUES (?, ?)", [
+        userId,
+        podRes.lastID,
+      ]);
+
+      const res = await request(app)
+        .post(`/api/pods/${podRes.lastID}/owners`)
+        .set("Authorization", `Bearer ${accessTokenUser}`)
+        .send({ userId: 0 });
+
+      expect(res.status).to.equal(400);
+      expect(res.body).to.have.property("error");
+      expect(res.body.error).to.equal("Validation failed");
+    });
+
+    it("should return 400 when userId is invalid (negative)", async () => {
+      const podRes = await db.run(
+        "INSERT INTO pod (pod_name, pod_data_public) VALUES (?, ?)",
+        ["OwnedPod", 0]
+      );
+
+      await db.run("INSERT INTO user_pod (user_id, pod_id) VALUES (?, ?)", [
+        userId,
+        podRes.lastID,
+      ]);
+
+      const res = await request(app)
+        .post(`/api/pods/${podRes.lastID}/owners`)
+        .set("Authorization", `Bearer ${accessTokenUser}`)
+        .send({ userId: -5 });
+
+      expect(res.status).to.equal(400);
+      expect(res.body).to.have.property("error");
+      expect(res.body.error).to.equal("Validation failed");
+    });
+
+    it("should return 400 when userId is missing from body", async () => {
+      const podRes = await db.run(
+        "INSERT INTO pod (pod_name, pod_data_public) VALUES (?, ?)",
+        ["OwnedPod", 0]
+      );
+
+      await db.run("INSERT INTO user_pod (user_id, pod_id) VALUES (?, ?)", [
+        userId,
+        podRes.lastID,
+      ]);
+
+      const res = await request(app)
+        .post(`/api/pods/${podRes.lastID}/owners`)
+        .set("Authorization", `Bearer ${accessTokenUser}`)
+        .send({});
+
+      expect(res.status).to.equal(400);
+      expect(res.body).to.have.property("error");
+      expect(res.body.error).to.equal("Validation failed");
+    });
+
+    it("should return 400 when userId is not an integer (string)", async () => {
+      const podRes = await db.run(
+        "INSERT INTO pod (pod_name, pod_data_public) VALUES (?, ?)",
+        ["OwnedPod", 0]
+      );
+
+      await db.run("INSERT INTO user_pod (user_id, pod_id) VALUES (?, ?)", [
+        userId,
+        podRes.lastID,
+      ]);
+
+      const res = await request(app)
+        .post(`/api/pods/${podRes.lastID}/owners`)
+        .set("Authorization", `Bearer ${accessTokenUser}`)
+        .send({ userId: "not-a-number" });
+
+      expect(res.status).to.equal(400);
+      expect(res.body).to.have.property("error");
+      expect(res.body.error).to.equal("Validation failed");
+    });
+
+    it("should return correct response body structure on success", async () => {
+      const podRes = await db.run(
+        "INSERT INTO pod (pod_name, pod_data_public) VALUES (?, ?)",
+        ["OwnedPod", 0]
+      );
+
+      await db.run("INSERT INTO user_pod (user_id, pod_id) VALUES (?, ?)", [
+        userId,
+        podRes.lastID,
+      ]);
+
+      const res = await request(app)
+        .post(`/api/pods/${podRes.lastID}/owners`)
+        .set("Authorization", `Bearer ${accessTokenUser}`)
+        .send({ userId: collaboratorId });
+
+      expect(res.status).to.equal(201);
+      expect(res.body).to.have.property("message");
+      expect(res.body).to.have.property("podId");
+      expect(res.body).to.have.property("userId");
+      expect(res.body.message).to.equal("Pod owner added successfully");
+      expect(res.body.podId).to.equal(String(podRes.lastID));
+      expect(res.body.userId).to.equal(String(collaboratorId));
+    });
+
+    it("should return validation details when pod_id is invalid", async () => {
+      const res = await request(app)
+        .post("/api/pods/-1/owners")
+        .set("Authorization", `Bearer ${accessTokenUser}`)
+        .send({ userId: collaboratorId });
+
+      expect(res.status).to.equal(400);
+      expect(res.body).to.have.property("details");
+      expect(res.body.details).to.be.an("array");
+      expect(res.body.details[0]).to.have.property("field");
+      expect(res.body.details[0]).to.have.property("message");
+    });
+
+    it("should return validation details when userId is invalid", async () => {
+      const podRes = await db.run(
+        "INSERT INTO pod (pod_name, pod_data_public) VALUES (?, ?)",
+        ["OwnedPod", 0]
+      );
+
+      await db.run("INSERT INTO user_pod (user_id, pod_id) VALUES (?, ?)", [
+        userId,
+        podRes.lastID,
+      ]);
+
+      const res = await request(app)
+        .post(`/api/pods/${podRes.lastID}/owners`)
+        .set("Authorization", `Bearer ${accessTokenUser}`)
+        .send({ userId: -1 });
+
+      expect(res.status).to.equal(400);
+      expect(res.body).to.have.property("details");
+      expect(res.body.details).to.be.an("array");
+      expect(res.body.details[0]).to.have.property("field");
+      expect(res.body.details[0]).to.have.property("message");
     });
   });
 

--- a/backend/test/API/pod.test.mjs
+++ b/backend/test/API/pod.test.mjs
@@ -174,6 +174,62 @@ describe("Pod API Tests", function () {
       expect(names).to.include("PublicPod");
       expect(names).to.include("PrivatePod");
     });
+
+    it("should set isOwner=true only for pods the authenticated user owns", async () => {
+      const ownedPod = await db.run(
+        "INSERT INTO pod (pod_name, pod_data_public) VALUES (?, ?)",
+        ["OwnedPod", 1]
+      );
+      const otherPod = await db.run(
+        "INSERT INTO pod (pod_name, pod_data_public) VALUES (?, ?)",
+        ["OtherPod", 1]
+      );
+
+      await db.run("INSERT INTO user_pod (user_id, pod_id) VALUES (?, ?)", [
+        userId,
+        ownedPod.lastID,
+      ]);
+
+      await db.run(
+        "INSERT INTO pod_data (pod_id, latitude, longitude) VALUES (?, ?, ?)",
+        [ownedPod.lastID, 40, -74]
+      );
+      await db.run(
+        "INSERT INTO pod_data (pod_id, latitude, longitude) VALUES (?, ?, ?)",
+        [otherPod.lastID, 40, -74]
+      );
+
+      const res = await request(app)
+        .get("/api/pods/locations")
+        .set("Authorization", `Bearer ${accessTokenUser}`)
+        .query({ latitude: 40, longitude: -74, radius: 5000 });
+
+      expect(res.status).to.equal(200);
+      const owned = res.body.pods.find((p) => p.nickname === "OwnedPod");
+      const other = res.body.pods.find((p) => p.nickname === "OtherPod");
+      expect(owned.isOwner).to.equal(true);
+      expect(other.isOwner).to.equal(false);
+    });
+
+    it("should set isOwner=false for all pods when anonymous", async () => {
+      const pubPod = await db.run(
+        "INSERT INTO pod (pod_name, pod_data_public) VALUES (?, ?)",
+        ["PublicPod", 1]
+      );
+
+      await db.run(
+        "INSERT INTO pod_data (pod_id, latitude, longitude) VALUES (?, ?, ?)",
+        [pubPod.lastID, 40, -74]
+      );
+
+      const res = await request(app)
+        .get("/api/pods/locations")
+        .query({ latitude: 40, longitude: -74, radius: 5000 });
+
+      expect(res.status).to.equal(200);
+      const pod = res.body.pods.find((p) => p.nickname === "PublicPod");
+      expect(pod.isOwner).to.equal(false);
+    });
   });
 
   // -------------------------

--- a/backend/test/API/pod.test.mjs
+++ b/backend/test/API/pod.test.mjs
@@ -12,9 +12,11 @@ describe("Pod API Tests", function () {
   let accessTokenAdmin;
   let userId;
   let adminId;
+  let collaboratorId;
 
   const userEmail = "testuser1@example.com";
   const adminEmail = "admin@example.com";
+  const collaboratorEmail = "collab@example.com";
 
   beforeEach(async () => {
     db = await createTestDb();
@@ -44,6 +46,19 @@ describe("Pod API Tests", function () {
     await db.run(
       "INSERT INTO user_contact (user_id, user_name, email) VALUES (?, ?, ?)",
       [adminId, "Admin User", adminEmail]
+    );
+
+    // collaborator user
+    const collaboratorHash = await bcrypt.hash("Password1", 12);
+    const collaboratorInsert = await db.run(
+      "INSERT INTO users (username, password_hash, admin) VALUES (?, ?, ?)",
+      ["CollaboratorUser", collaboratorHash, 0]
+    );
+    collaboratorId = collaboratorInsert.lastID;
+
+    await db.run(
+      "INSERT INTO user_contact (user_id, user_name, email) VALUES (?, ?, ?)",
+      [collaboratorId, "Collaborator User", collaboratorEmail]
     );
 
     // login user
@@ -266,6 +281,92 @@ describe("Pod API Tests", function () {
 
       const res = await request(app).get(`/api/pods/${podRes.lastID}/data`);
       expect(res.status).to.equal(403);
+    });
+  });
+
+  // -------------------------
+  // POST /api/pods/:id/owners
+  // -------------------------
+  describe("POST /api/pods/:id/owners", () => {
+    it("should allow a pod owner to add another owner", async () => {
+      const podRes = await db.run(
+        "INSERT INTO pod (pod_name, pod_data_public) VALUES (?, ?)",
+        ["OwnedPod", 0]
+      );
+
+      await db.run("INSERT INTO user_pod (user_id, pod_id) VALUES (?, ?)", [
+        userId,
+        podRes.lastID,
+      ]);
+
+      const res = await request(app)
+        .post(`/api/pods/${podRes.lastID}/owners`)
+        .set("Authorization", `Bearer ${accessTokenUser}`)
+        .send({ userId: collaboratorId });
+
+      expect(res.status).to.equal(201);
+
+      const ownerRow = await db.get(
+        "SELECT 1 FROM user_pod WHERE user_id = ? AND pod_id = ?",
+        [collaboratorId, podRes.lastID]
+      );
+      expect(ownerRow).to.not.equal(undefined);
+    });
+
+    it("should reject adding an owner when requester does not own pod", async () => {
+      const podRes = await db.run(
+        "INSERT INTO pod (pod_name, pod_data_public) VALUES (?, ?)",
+        ["NotOwnedPod", 0]
+      );
+
+      const res = await request(app)
+        .post(`/api/pods/${podRes.lastID}/owners`)
+        .set("Authorization", `Bearer ${accessTokenUser}`)
+        .send({ userId: collaboratorId });
+
+      expect(res.status).to.equal(403);
+    });
+
+    it("should return 404 when target user does not exist", async () => {
+      const podRes = await db.run(
+        "INSERT INTO pod (pod_name, pod_data_public) VALUES (?, ?)",
+        ["OwnedPod", 0]
+      );
+
+      await db.run("INSERT INTO user_pod (user_id, pod_id) VALUES (?, ?)", [
+        userId,
+        podRes.lastID,
+      ]);
+
+      const res = await request(app)
+        .post(`/api/pods/${podRes.lastID}/owners`)
+        .set("Authorization", `Bearer ${accessTokenUser}`)
+        .send({ userId: 99999 });
+
+      expect(res.status).to.equal(404);
+    });
+
+    it("should return 409 when target user is already an owner", async () => {
+      const podRes = await db.run(
+        "INSERT INTO pod (pod_name, pod_data_public) VALUES (?, ?)",
+        ["OwnedPod", 0]
+      );
+
+      await db.run("INSERT INTO user_pod (user_id, pod_id) VALUES (?, ?)", [
+        userId,
+        podRes.lastID,
+      ]);
+      await db.run("INSERT INTO user_pod (user_id, pod_id) VALUES (?, ?)", [
+        collaboratorId,
+        podRes.lastID,
+      ]);
+
+      const res = await request(app)
+        .post(`/api/pods/${podRes.lastID}/owners`)
+        .set("Authorization", `Bearer ${accessTokenUser}`)
+        .send({ userId: collaboratorId });
+
+      expect(res.status).to.equal(409);
     });
   });
 

--- a/frontend/src/components/Map.tsx
+++ b/frontend/src/components/Map.tsx
@@ -5,6 +5,10 @@ import "../styles/Map.css";
 import Controls from "./map/Controls";
 import PodMarkers from "./map/PodMarkers";
 
+type MapViewProps = {
+    isAuthenticated?: boolean | null;
+};
+
 const MAP_VIEW_STORAGE_KEY = "eva.mapView";
 const BASE_LAYER_STORAGE_KEY = "eva.baseLayer";
 const BASE_LAYER_OPEN_STREET_MAP = "OpenStreetMap";
@@ -87,7 +91,7 @@ function PersistMapView() {
     return null;
 }
 
-export default function MapView() {
+export default function MapView({ isAuthenticated }: MapViewProps) {
     const savedView = readSavedMapView();
     const savedBaseLayer = readSavedBaseLayer();
     const initialCenter: [number, number] = savedView ? [savedView.lat, savedView.lng] : DEFAULT_CENTER;
@@ -122,7 +126,7 @@ export default function MapView() {
         </LayersControlAny>
 
         <PodMarkers />
-        <Controls />
+        <Controls isAuthenticated={isAuthenticated} />
         <PersistMapView />
 
 

--- a/frontend/src/components/SharePodModal.tsx
+++ b/frontend/src/components/SharePodModal.tsx
@@ -9,13 +9,14 @@ type SharePodModalProps = {
   show: boolean;
   podId: string;
   onClose: () => void;
+  currentOwnerIds?: number[];
 };
 
 function getCandidateInitial(candidate: PodOwnerCandidate): string {
   return (candidate.username || "?").charAt(0).toUpperCase();
 }
 
-export default function SharePodModal({ show, podId, onClose }: SharePodModalProps) {
+export default function SharePodModal({ show, podId, onClose, currentOwnerIds = [] }: SharePodModalProps) {
   const [query, setQuery] = useState("");
   const [results, setResults] = useState<PodOwnerCandidate[]>([]);
   const [isSearching, setIsSearching] = useState(false);
@@ -149,26 +150,29 @@ export default function SharePodModal({ show, podId, onClose }: SharePodModalPro
             <div className="share-modal-empty">No matching users found.</div>
           ) : (
             <ul className="share-modal-list">
-              {results.map((candidate) => (
-                <li key={candidate.id} className="share-modal-item">
-                  <div className="share-modal-user">
-                    <span className="share-modal-avatar" aria-hidden="true">
-                      {getCandidateInitial(candidate)}
-                    </span>
-                    <div className="share-modal-user-text">
-                      <span className="share-modal-username">{candidate.username}</span>
+              {results.map((candidate) => {
+                const isAlreadyOwner = currentOwnerIds.includes(candidate.id);
+                return (
+                  <li key={candidate.id} className="share-modal-item">
+                    <div className="share-modal-user">
+                      <span className="share-modal-avatar" aria-hidden="true">
+                        {getCandidateInitial(candidate)}
+                      </span>
+                      <div className="share-modal-user-text">
+                        <span className="share-modal-username">{candidate.username}</span>
+                      </div>
                     </div>
-                  </div>
-                  <button
-                    type="button"
-                    className="share-modal-add-btn"
-                    onClick={() => handleAddOwner(candidate)}
-                    disabled={addingUserId === candidate.id}
-                  >
-                    {addingUserId === candidate.id ? "Adding..." : "Add"}
-                  </button>
-                </li>
-              ))}
+                    <button
+                      type="button"
+                      className="share-modal-add-btn"
+                      onClick={() => handleAddOwner(candidate)}
+                      disabled={isAlreadyOwner || addingUserId === candidate.id}
+                    >
+                      {isAlreadyOwner ? "Already an Owner" : addingUserId === candidate.id ? "Adding..." : "Add"}
+                    </button>
+                  </li>
+                );
+              })}
             </ul>
           )}
         </div>

--- a/frontend/src/components/SharePodModal.tsx
+++ b/frontend/src/components/SharePodModal.tsx
@@ -1,0 +1,171 @@
+import { useEffect, useMemo, useState } from "react";
+import { FiSearch, FiX } from "react-icons/fi";
+
+import { addPodOwner, ApiError } from "../utils/api";
+import type { PodOwnerCandidate } from "../utils/apiTypes";
+import "../styles/SharePodModal.css";
+
+type SharePodModalProps = {
+  show: boolean;
+  podId: string;
+  onClose: () => void;
+};
+
+function getCandidateInitial(candidate: PodOwnerCandidate): string {
+  const source = candidate.username || candidate.email || "?";
+  return source.charAt(0).toUpperCase();
+}
+
+export default function SharePodModal({ show, podId, onClose }: SharePodModalProps) {
+  const [query, setQuery] = useState("");
+  const [results, setResults] = useState<PodOwnerCandidate[]>([]);
+  const [isSearching, setIsSearching] = useState(false);
+  const [searchError, setSearchError] = useState<string | null>(null);
+  const [addingUserId, setAddingUserId] = useState<string | null>(null);
+  const [feedback, setFeedback] = useState<string | null>(null);
+
+  const trimmedQuery = useMemo(() => query.trim(), [query]);
+
+  useEffect(() => {
+    if (!show) return;
+    setQuery("");
+    setResults([]);
+    setIsSearching(false);
+    setSearchError(null);
+    setAddingUserId(null);
+    setFeedback(null);
+  }, [show, podId]);
+
+  useEffect(() => {
+    if (!show) return;
+
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") onClose();
+    };
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  }, [show, onClose]);
+
+  useEffect(() => {
+    if (!show) return;
+    if (!podId || trimmedQuery.length < 2) {
+      setResults([]);
+      setSearchError(null);
+      return;
+    }
+
+    let cancelled = false;
+    let ac: AbortController | null = null;
+    const timeoutId = window.setTimeout(() => {
+      ac = new AbortController();
+      setIsSearching(true);
+      setSearchError(null);
+
+      // TODO:
+    }, 250);
+
+    return () => {
+      cancelled = true;
+      window.clearTimeout(timeoutId);
+      ac?.abort();
+    };
+  }, [show, podId, trimmedQuery]);
+
+  async function handleAddOwner(candidate: PodOwnerCandidate): Promise<void> {
+    setFeedback(null);
+    setAddingUserId(candidate.id);
+    try {
+      await addPodOwner(podId, { userId: candidate.id });
+      setResults((prev) => prev.filter((user) => user.id !== candidate.id));
+      setFeedback(`Added ${candidate.username} as an owner.`);
+    } catch (e: unknown) {
+      if (e instanceof ApiError && e.status === 409) {
+        setFeedback(`${candidate.username} is already an owner.`);
+      } else {
+        const message = e instanceof Error ? e.message : "Failed to add owner.";
+        setFeedback(message);
+      }
+    } finally {
+      setAddingUserId(null);
+    }
+  }
+
+  if (!show) return null;
+
+  return (
+    <div className="share-modal-overlay" role="presentation" onClick={onClose}>
+      <div
+        className="share-modal"
+        role="dialog"
+        aria-modal="true"
+        aria-label="Add collaborators"
+        onClick={(event) => event.stopPropagation()}
+      >
+        <header className="share-modal-header">
+          <div>
+            <h2 className="share-modal-title">Add collaborators</h2>
+            <p className="share-modal-subtitle">Search by username or email</p>
+          </div>
+          <button type="button" className="share-modal-close" aria-label="Close" onClick={onClose}>
+            <FiX size={18} />
+          </button>
+        </header>
+
+        <div className="share-modal-search-wrap">
+          <FiSearch size={16} className="share-modal-search-icon" aria-hidden="true" />
+          <input
+            type="text"
+            className="share-modal-search-input"
+            placeholder="Search people..."
+            value={query}
+            onChange={(event) => setQuery(event.target.value)}
+            autoFocus
+          />
+        </div>
+
+        {feedback ? <div className="share-modal-feedback">{feedback}</div> : null}
+        {searchError ? <div className="share-modal-error">{searchError}</div> : null}
+
+        <div className="share-modal-results">
+          {trimmedQuery.length < 2 ? (
+            <div className="share-modal-empty">Type at least 2 characters to search.</div>
+          ) : isSearching ? (
+            <div className="share-modal-empty">Searching...</div>
+          ) : results.length === 0 ? (
+            <div className="share-modal-empty">No matching users found.</div>
+          ) : (
+            <ul className="share-modal-list">
+              {results.map((candidate) => (
+                <li key={candidate.id} className="share-modal-item">
+                  <div className="share-modal-user">
+                    <span className="share-modal-avatar" aria-hidden="true">
+                      {getCandidateInitial(candidate)}
+                    </span>
+                    <div className="share-modal-user-text">
+                      <span className="share-modal-username">{candidate.username}</span>
+                      <span className="share-modal-email">{candidate.email ?? "No email available"}</span>
+                    </div>
+                  </div>
+                  <button
+                    type="button"
+                    className="share-modal-add-btn"
+                    onClick={() => handleAddOwner(candidate)}
+                    disabled={addingUserId === candidate.id}
+                  >
+                    {addingUserId === candidate.id ? "Adding..." : "Add"}
+                  </button>
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+
+        <footer className="share-modal-footer">
+          <button type="button" className="share-modal-done-btn" onClick={onClose}>
+            Done
+          </button>
+        </footer>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/SharePodModal.tsx
+++ b/frontend/src/components/SharePodModal.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useMemo, useState } from "react";
 import { FiSearch, FiX } from "react-icons/fi";
 
-import { addPodOwner, ApiError } from "../utils/api";
+import { addPodOwner, ApiError, searchUsers } from "../utils/api";
 import type { PodOwnerCandidate } from "../utils/apiTypes";
 import "../styles/SharePodModal.css";
 
@@ -12,8 +12,7 @@ type SharePodModalProps = {
 };
 
 function getCandidateInitial(candidate: PodOwnerCandidate): string {
-  const source = candidate.username || candidate.email || "?";
-  return source.charAt(0).toUpperCase();
+  return (candidate.username || "?").charAt(0).toUpperCase();
 }
 
 export default function SharePodModal({ show, podId, onClose }: SharePodModalProps) {
@@ -21,7 +20,7 @@ export default function SharePodModal({ show, podId, onClose }: SharePodModalPro
   const [results, setResults] = useState<PodOwnerCandidate[]>([]);
   const [isSearching, setIsSearching] = useState(false);
   const [searchError, setSearchError] = useState<string | null>(null);
-  const [addingUserId, setAddingUserId] = useState<string | null>(null);
+  const [addingUserId, setAddingUserId] = useState<number | null>(null);
   const [feedback, setFeedback] = useState<string | null>(null);
 
   const trimmedQuery = useMemo(() => query.trim(), [query]);
@@ -61,7 +60,22 @@ export default function SharePodModal({ show, podId, onClose }: SharePodModalPro
       setIsSearching(true);
       setSearchError(null);
 
-      // TODO:
+      searchUsers(trimmedQuery, ac.signal)
+        .then((res) => {
+          if (cancelled) return;
+          setResults(Array.isArray(res.users) ? res.users : []);
+        })
+        .catch((e: unknown) => {
+          if (cancelled) return;
+          if ((e as { name?: string })?.name === "AbortError") return;
+          const message = e instanceof Error ? e.message : "Failed to search users.";
+          setSearchError(message);
+          setResults([]);
+        })
+        .finally(() => {
+          if (cancelled) return;
+          setIsSearching(false);
+        });
     }, 250);
 
     return () => {
@@ -104,7 +118,7 @@ export default function SharePodModal({ show, podId, onClose }: SharePodModalPro
         <header className="share-modal-header">
           <div>
             <h2 className="share-modal-title">Add collaborators</h2>
-            <p className="share-modal-subtitle">Search by username or email</p>
+            <p className="share-modal-subtitle">Search by username</p>
           </div>
           <button type="button" className="share-modal-close" aria-label="Close" onClick={onClose}>
             <FiX size={18} />
@@ -143,7 +157,6 @@ export default function SharePodModal({ show, podId, onClose }: SharePodModalPro
                     </span>
                     <div className="share-modal-user-text">
                       <span className="share-modal-username">{candidate.username}</span>
-                      <span className="share-modal-email">{candidate.email ?? "No email available"}</span>
                     </div>
                   </div>
                   <button

--- a/frontend/src/components/SharePodModal.tsx
+++ b/frontend/src/components/SharePodModal.tsx
@@ -23,6 +23,7 @@ export default function SharePodModal({ show, podId, onClose, currentOwnerIds = 
   const [searchError, setSearchError] = useState<string | null>(null);
   const [addingUserId, setAddingUserId] = useState<number | null>(null);
   const [feedback, setFeedback] = useState<string | null>(null);
+  const [localOwnerIds, setLocalOwnerIds] = useState<number[]>([]);
 
   const trimmedQuery = useMemo(() => query.trim(), [query]);
 
@@ -34,7 +35,8 @@ export default function SharePodModal({ show, podId, onClose, currentOwnerIds = 
     setSearchError(null);
     setAddingUserId(null);
     setFeedback(null);
-  }, [show, podId]);
+    setLocalOwnerIds(currentOwnerIds);
+  }, [show, podId, currentOwnerIds]);
 
   useEffect(() => {
     if (!show) return;
@@ -91,8 +93,7 @@ export default function SharePodModal({ show, podId, onClose, currentOwnerIds = 
     setAddingUserId(candidate.id);
     try {
       await addPodOwner(podId, { userId: candidate.id });
-      setResults((prev) => prev.filter((user) => user.id !== candidate.id));
-      setFeedback(`Added ${candidate.username} as an owner.`);
+      setLocalOwnerIds((prev) => [...prev, candidate.id]);
     } catch (e: unknown) {
       if (e instanceof ApiError && e.status === 409) {
         setFeedback(`${candidate.username} is already an owner.`);
@@ -151,7 +152,7 @@ export default function SharePodModal({ show, podId, onClose, currentOwnerIds = 
           ) : (
             <ul className="share-modal-list">
               {results.map((candidate) => {
-                const isAlreadyOwner = currentOwnerIds.includes(candidate.id);
+                const isAlreadyOwner = localOwnerIds.includes(candidate.id);
                 return (
                   <li key={candidate.id} className="share-modal-item">
                     <div className="share-modal-user">

--- a/frontend/src/components/map/Controls.tsx
+++ b/frontend/src/components/map/Controls.tsx
@@ -54,7 +54,7 @@ function Geocoder() {
   return null;
 }
 
-function LegendControl() {
+function LegendControl({ isAuthenticated }: { isAuthenticated?: boolean | null }) {
   const map = useMap() as any;
 
   useEffect(() => {
@@ -92,11 +92,13 @@ function LegendControl() {
       const label = (L as any).DomUtil.create("span", "", row);
       label.textContent = "EVA Pod";
 
-      ownedSwatch = (L as any).DomUtil.create("span", "eva-legend-swatch eva-legend-swatch-owned");
-      const ownedRow = (L as any).DomUtil.create("div", "eva-legend-row", div);
-      ownedRow.appendChild(ownedSwatch);
-      const ownedLabel = (L as any).DomUtil.create("span", "", ownedRow);
-      ownedLabel.textContent = "Your Pod";
+      if (isAuthenticated) {
+        ownedSwatch = (L as any).DomUtil.create("span", "eva-legend-swatch eva-legend-swatch-owned");
+        const ownedRow = (L as any).DomUtil.create("div", "eva-legend-row", div);
+        ownedRow.appendChild(ownedSwatch);
+        const ownedLabel = (L as any).DomUtil.create("span", "", ownedRow);
+        ownedLabel.textContent = "Your Pod";
+      }
 
       (L as any).DomEvent.disableClickPropagation(div);
       (L as any).DomEvent.disableScrollPropagation(div);
@@ -105,7 +107,6 @@ function LegendControl() {
 
       return div;
     };
-
     control.addTo(map);
     map.on("zoomend", updateSwatch);
 
@@ -117,7 +118,7 @@ function LegendControl() {
         // no-op
       }
     };
-  }, [map]);
+  }, [map, isAuthenticated]);
 
   return null;
 }
@@ -329,12 +330,12 @@ function UserLocationControl() {
   return null;
 }
 
-export default function Controls() {
+export default function Controls({ isAuthenticated }: { isAuthenticated?: boolean | null }) {
   // Preserve the existing add-to-map ordering:
   // Legend (top-right), then Geocoder (top-left), then Search this area (top-left), then User Location (top-left).
   return (
     <>
-      <LegendControl />
+      <LegendControl isAuthenticated={isAuthenticated} />
       <Geocoder />
       <SearchAreaControl />
       <UserLocationControl />

--- a/frontend/src/components/map/Controls.tsx
+++ b/frontend/src/components/map/Controls.tsx
@@ -61,8 +61,10 @@ function LegendControl() {
     const control: any = (L as any).control({ position: "topright" });
 
     let swatch: HTMLElement | null = null;
+    let ownedSwatch: HTMLElement | null = null;
+
     function updateSwatch() {
-      if (!swatch) return;
+      if (!swatch || !ownedSwatch) return;
       const center = map.getCenter();
       const zoom = map.getZoom();
       const isPin = shouldUsePinAtZoom(MARKER_BASE_RADIUS_METERS, center.lat, zoom, MARKER_MIN_VISIBLE_RADIUS_PX);
@@ -70,23 +72,31 @@ function LegendControl() {
       if (isPin) {
         swatch.className = "pod-pin-icon eva-legend-swatch-pin";
         swatch.innerHTML = '<span class="pod-pin-marker" aria-hidden="true"></span>';
+        ownedSwatch.className = "pod-pin-icon eva-legend-swatch-pin";
+        ownedSwatch.innerHTML = '<span class="pod-pin-marker pod-pin-marker-owned" aria-hidden="true"></span>';
       } else {
         swatch.className = "eva-legend-swatch";
         swatch.innerHTML = "";
+        ownedSwatch.className = "eva-legend-swatch eva-legend-swatch-owned";
+        ownedSwatch.innerHTML = "";
       }
     }
 
     control.onAdd = () => {
       // Reuse existing Leaflet control styling from Map.css by using leaflet-control-layers classes.
       const div = (L as any).DomUtil.create("div", "leaflet-control-layers leaflet-control eva-legend");
-      div.innerHTML = ``;
       swatch = (L as any).DomUtil.create("span", "eva-legend-swatch");
 
       const row = (L as any).DomUtil.create("div", "eva-legend-row", div);
       row.appendChild(swatch);
-
       const label = (L as any).DomUtil.create("span", "", row);
       label.textContent = "EVA Pod";
+
+      ownedSwatch = (L as any).DomUtil.create("span", "eva-legend-swatch eva-legend-swatch-owned");
+      const ownedRow = (L as any).DomUtil.create("div", "eva-legend-row", div);
+      ownedRow.appendChild(ownedSwatch);
+      const ownedLabel = (L as any).DomUtil.create("span", "", ownedRow);
+      ownedLabel.textContent = "Your Pod";
 
       (L as any).DomEvent.disableClickPropagation(div);
       (L as any).DomEvent.disableScrollPropagation(div);

--- a/frontend/src/components/map/PodMarkers.tsx
+++ b/frontend/src/components/map/PodMarkers.tsx
@@ -104,6 +104,17 @@ export default function PodMarkers() {
     [],
   );
 
+  const pinIconOwned = useMemo(
+    () =>
+      L.divIcon({
+        className: "pod-pin-icon",
+        html: '<span class="pod-pin-marker pod-pin-marker-owned" aria-hidden="true"></span>',
+        iconSize: [PIN_ICON_WIDTH_PX, PIN_ICON_HEIGHT_PX],
+        iconAnchor: [PIN_ICON_WIDTH_PX / 2, PIN_ICON_HEIGHT_PX],
+      }),
+    [],
+  );
+
   async function fetchPods(map: MapLike) {
     abortRef.current?.abort();
     const ac = new AbortController();
@@ -289,7 +300,7 @@ export default function PodMarkers() {
             <Marker
               key={p.id}
               position={[p.latitude, p.longitude]}
-              icon={pinIcon}
+              icon={p.isOwner ? pinIconOwned : pinIcon}
               eventHandlers={{
                 click: (e: any) => handlePodClick(p, e),
               }}
@@ -304,7 +315,7 @@ export default function PodMarkers() {
             key={p.id}
             center={[p.latitude, p.longitude]}
             radius={markerRadiusMeters}
-            pathOptions={{ color: "red", weight: 2, fillOpacity: 0.5 }}
+            pathOptions={p.isOwner ? { color: "#30A46C", weight: 2, fillOpacity: 0.5 } : { color: "red", weight: 2, fillOpacity: 0.5 }}
             eventHandlers={{
               click: (e: any) => handlePodClick(p, e),
             }}

--- a/frontend/src/components/map/PodMarkers.tsx
+++ b/frontend/src/components/map/PodMarkers.tsx
@@ -172,6 +172,12 @@ export default function PodMarkers() {
     // map is stable for the lifetime of the MapContainer
   }, [map]);
 
+  useEffect(() => {
+    const handleLogin = () => void fetchPods(map as unknown as MapLike);
+    window.addEventListener("eva.login", handleLogin);
+    return () => window.removeEventListener("eva.login", handleLogin);
+  }, [map]);
+
   function closeTooltip() {
     if (!tooltipPodId) return;
     setTooltipVisible(false);

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -104,7 +104,7 @@ export default function Home() {
                 ) : null}
             </div>
             <div className="map-container">
-                <MapView />
+                <MapView isAuthenticated={isAuthenticated} />
             </div>
         </div>
     )

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -94,6 +94,7 @@ export default function Home() {
                                 const profile = await getMe();
                                 setUser(profile.user);
                                 setIsAuthenticated(true);
+                                window.dispatchEvent(new Event("eva.login"));
                             } catch {
                                 setUser(null);
                                 setIsAuthenticated(false);

--- a/frontend/src/pages/Pod.tsx
+++ b/frontend/src/pages/Pod.tsx
@@ -203,7 +203,7 @@ export default function Pod() {
           <div className="pod-meta">
             <div>Last updated: {lastUpdatedDate ? formatDateMDY(lastUpdatedDate) : "—"}</div>
           </div>
-          {viewer?.isOwner && (
+          {viewer?.canManagePod && (
             <>
             <button className="pod-action" type="button" title="Upload/Export (placeholder)">
               <FiUpload size={28} />

--- a/frontend/src/pages/Pod.tsx
+++ b/frontend/src/pages/Pod.tsx
@@ -1,10 +1,11 @@
 import { useEffect, useMemo, useState } from "react";
 import { useParams } from "react-router-dom";
-import { FiUpload } from "react-icons/fi";
+import { FiUpload, FiShare2 } from "react-icons/fi";
 
 import "../styles/Pod.css";
 import { getPodData } from "../utils/api";
 import type { PodDataEntry } from "../utils/apiTypes";
+import SharePodModal from "../components/SharePodModal";
 
 function titleCaseSensor(value: string): string {
   const raw = String(value ?? "").trim();
@@ -58,10 +59,17 @@ export default function Pod() {
     visibility: "public" | "private";
     lastUpdated: string;
   } | null>(null);
+  const [viewer, setViewer] = useState<{
+    isAuthenticated: boolean;
+    isOwner: boolean;
+    isAdmin: boolean;
+    canManagePod: boolean;
+  } | null>(null);
 
   const [selectedSensor, setSelectedSensor] = useState<string>("");
   const [selectedRange, setSelectedRange] = useState<string>("Last 7 Days");
   const [selectedDay, setSelectedDay] = useState<string>("");
+  const [showShareModal, setShowShareModal] = useState<boolean>(false);
 
   useEffect(() => {
     if (!podId) {
@@ -85,12 +93,14 @@ export default function Pod() {
           visibility: res.visibility,
           lastUpdated: res.lastUpdated,
         });
+        setViewer(res.viewer ?? null);
         setData(Array.isArray(res.data) ? res.data : []);
       } catch (e: any) {
         if (e?.name === "AbortError") return;
         setError(e?.message ? String(e.message) : "Failed to load pod data.");
         setData([]);
         setPodMeta(null);
+        setViewer(null);
       } finally {
         setLoading(false);
       }
@@ -167,9 +177,21 @@ export default function Pod() {
           <div className="pod-meta">
             <div>Last updated: {lastUpdatedDate ? formatDateMDY(lastUpdatedDate) : "—"}</div>
           </div>
-          <button className="pod-action" type="button" title="Upload/Export (placeholder)">
-            <FiUpload size={28} />
-          </button>
+          {viewer?.isOwner && (
+            <>
+            <button className="pod-action" type="button" title="Upload/Export (placeholder)">
+              <FiUpload size={28} />
+            </button>
+            <button
+              className="pod-action"
+              type="button"
+              title="Share Pod"
+              onClick={() => setShowShareModal(true)}
+            >
+              <FiShare2 size={28} />
+            </button>
+            </>
+          )}
         </div>
       </section>
 
@@ -283,8 +305,13 @@ export default function Pod() {
           ) : null}
         </>
       )}
+
+      <SharePodModal
+        show={showShareModal}
+        podId={podMeta?.id ?? podId ?? ""}
+        onClose={() => setShowShareModal(false)}
+      />
     </div>
   );
 }
-
 

--- a/frontend/src/pages/Pod.tsx
+++ b/frontend/src/pages/Pod.tsx
@@ -3,9 +3,11 @@ import { useParams } from "react-router-dom";
 import { FiUpload, FiShare2 } from "react-icons/fi";
 
 import "../styles/Pod.css";
-import { getPodData } from "../utils/api";
-import type { PodDataEntry } from "../utils/apiTypes";
+import { getPodData, getPodOwners } from "../utils/api";
+import type { PodDataEntry, PodOwnerCandidate } from "../utils/apiTypes";
 import SharePodModal from "../components/SharePodModal";
+import SensorTrendChart from "../components/SensorTrendChart";
+import DailySensorChart from "../components/DailySensorChart";
 
 function titleCaseSensor(value: string): string {
   const raw = String(value ?? "").trim();
@@ -66,10 +68,12 @@ export default function Pod() {
     canManagePod: boolean;
   } | null>(null);
 
-  const [selectedSensor, setSelectedSensor] = useState<string>("");
+  const [selectedSensorOverall, setSelectedSensorOverall] = useState<string>("");
+  const [selectedSensorDaily, setSelectedSensorDaily] = useState<string>("");
   const [selectedRange, setSelectedRange] = useState<string>("Last 7 Days");
   const [selectedDay, setSelectedDay] = useState<string>("");
   const [showShareModal, setShowShareModal] = useState<boolean>(false);
+  const [podOwners, setPodOwners] = useState<PodOwnerCandidate[]>([]);
 
   useEffect(() => {
     if (!podId) {
@@ -131,9 +135,14 @@ export default function Pod() {
   }, [data]);
 
   useEffect(() => {
-    if (selectedSensor) return;
-    if (sensorOptions.length > 0) setSelectedSensor(sensorOptions[0].key);
-  }, [sensorOptions, selectedSensor]);
+    if (selectedSensorOverall) return;
+    if (sensorOptions.length > 0) setSelectedSensorOverall(sensorOptions[0].key);
+  }, [sensorOptions, selectedSensorOverall]);
+
+  useEffect(() => {
+    if (selectedSensorDaily) return;
+    if (sensorOptions.length > 0) setSelectedSensorDaily(sensorOptions[0].key);
+  }, [sensorOptions, selectedSensorDaily]);
 
   const dayOptions = useMemo(() => {
     const seen = new Set<string>();
@@ -156,6 +165,23 @@ export default function Pod() {
     if (selectedDay) return;
     if (dayOptions.length > 0) setSelectedDay(dayOptions[0].key);
   }, [dayOptions, selectedDay]);
+
+  useEffect(() => {
+    if (!showShareModal) return;
+    if (!podMeta?.id) return;
+
+    const ac = new AbortController();
+    (async () => {
+      try {
+        const res = await getPodOwners(podMeta.id, ac.signal);
+        setPodOwners(res.owners ?? []);
+      } catch {
+        setPodOwners([]);
+      }
+    })();
+
+    return () => ac.abort();
+  }, [showShareModal, podMeta?.id]);
 
   // Latest cards are derived at render time from whatever sensor types exist (no hardcoding).
 
@@ -243,7 +269,7 @@ export default function Pod() {
             <div className="pod-section-header">
               <h2 className="pod-section-title">Sensor Trends</h2>
               <div className="pod-filters">
-                <select value={selectedSensor} onChange={(e) => setSelectedSensor(e.target.value)}>
+                <select value={selectedSensorOverall} onChange={(e) => setSelectedSensorOverall(e.target.value)}>
                   {sensorOptions.length === 0 ? <option value="">No sensors</option> : null}
                   {sensorOptions.map((o) => (
                     <option key={o.key} value={o.key}>
@@ -259,6 +285,11 @@ export default function Pod() {
               </div>
             </div>
             <div className="pod-chart">Insert boxplot of data over each day</div>
+            {/* <SensorTrendChart
+              data={data}
+              sensorType={selectedSensorOverall}
+              dateRange={selectedRange as "Last 7 Days" | "Last 30 Days" | "All Time"}
+            /> */}
           </section>
 
           <h2 className="pod-daily-title">Daily Data</h2>
@@ -285,7 +316,7 @@ export default function Pod() {
               <div className="pod-section-header">
                 <h2 className="pod-section-title">{`${formatDateMDY(new Date(selectedDay))} Sensor Trends`}</h2>
                 <div className="pod-filters">
-                  <select value={selectedSensor} onChange={(e) => setSelectedSensor(e.target.value)}>
+                  <select value={selectedSensorDaily} onChange={(e) => setSelectedSensorDaily(e.target.value)}>
                     {sensorOptions.length === 0 ? <option value="">No sensors</option> : null}
                     {sensorOptions.map((o) => (
                       <option key={o.key} value={o.key}>
@@ -293,14 +324,14 @@ export default function Pod() {
                       </option>
                     ))}
                   </select>
-                  <select value={selectedRange} onChange={(e) => setSelectedRange(e.target.value)}>
-                    <option value="Last 7 Days">Last 7 Days</option>
-                    <option value="Last 30 Days">Last 30 Days</option>
-                    <option value="All Time">All Time</option>
-                  </select>
                 </div>
               </div>
               <div className="pod-chart">Insert trendline/scatterplot of data over 24 hours</div>
+              {/* <DailySensorChart
+                data={data}
+                sensorType={selectedSensorDaily}
+                day={selectedDay}
+              /> */}
             </section>
           ) : null}
         </>
@@ -310,6 +341,7 @@ export default function Pod() {
         show={showShareModal}
         podId={podMeta?.id ?? podId ?? ""}
         onClose={() => setShowShareModal(false)}
+        currentOwnerIds={podOwners.map((o) => o.id)}
       />
     </div>
   );

--- a/frontend/src/pages/Pod.tsx
+++ b/frontend/src/pages/Pod.tsx
@@ -54,10 +54,10 @@ export default function Pod() {
   const [podMeta, setPodMeta] = useState<{
     id: string;
     nickname: string;
-    latitude: number;
-    longitude: number;
+    latitude: number | null;
+    longitude: number | null;
     visibility: "public" | "private";
-    lastUpdated: string;
+    lastUpdated: string | null;
   } | null>(null);
   const [viewer, setViewer] = useState<{
     isAuthenticated: boolean;

--- a/frontend/src/pages/Pod.tsx
+++ b/frontend/src/pages/Pod.tsx
@@ -139,7 +139,7 @@ export default function Pod() {
     const seen = new Set<string>();
     const days: { key: string; label: string }[] = [];
     for (const e of data) {
-      const ts = e?.data?.reading_timestamp || e?.timestamp;
+      const ts = e?.timestamp;
       if (!ts) continue;
       const d = new Date(ts);
       if (isNaN(d.getTime())) continue;

--- a/frontend/src/pages/Pod.tsx
+++ b/frontend/src/pages/Pod.tsx
@@ -6,8 +6,8 @@ import "../styles/Pod.css";
 import { getPodData, getPodOwners } from "../utils/api";
 import type { PodDataEntry, PodOwnerCandidate } from "../utils/apiTypes";
 import SharePodModal from "../components/SharePodModal";
-import SensorTrendChart from "../components/SensorTrendChart";
-import DailySensorChart from "../components/DailySensorChart";
+// import SensorTrendChart from "../components/SensorTrendChart";
+// import DailySensorChart from "../components/DailySensorChart";
 
 function titleCaseSensor(value: string): string {
   const raw = String(value ?? "").trim();

--- a/frontend/src/styles/Map.css
+++ b/frontend/src/styles/Map.css
@@ -188,6 +188,21 @@
     box-shadow: 0 0 0 3px rgba(255, 255, 255, 0.98);
 }
 
+.pod-pin-marker-owned {
+    background: rgba(48, 164, 108, 0.85);
+    border: 2px solid var(--primary-green);
+}
+
+.pod-pin-icon:hover .pod-pin-marker-owned {
+    background: rgba(48, 164, 108, 0.85);
+    border: 2px solid var(--primary-green);
+}
+
+.eva-legend-swatch-owned {
+    background: rgba(48, 164, 108, 0.5);
+    border: 2px solid var(--primary-green);
+}
+
 /* Search Area Button (top-left) */
 .eva-search-area {
     padding: 0;

--- a/frontend/src/styles/SharePodModal.css
+++ b/frontend/src/styles/SharePodModal.css
@@ -1,0 +1,234 @@
+.share-modal-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 6000;
+  display: flex;
+  align-items: flex-start;
+  justify-content: center;
+  padding: 7vh 16px 16px;
+  background: rgba(48, 53, 51, 0.7);
+  backdrop-filter: blur(2px);
+}
+
+.share-modal {
+  width: min(560px, 100%);
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  border-radius: 12px;
+  background: var(--secondary-green);
+  color: #ffffff;
+  box-shadow: 0 12px 36px rgba(0, 0, 0, 0.35);
+}
+
+.share-modal-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 16px;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.15);
+}
+
+.share-modal-title {
+  margin: 0;
+  font-size: 1.1rem;
+  font-weight: 700;
+  line-height: 1.2;
+}
+
+.share-modal-subtitle {
+  margin: 4px 0 0;
+  color: rgba(255, 255, 255, 0.78);
+  font-size: 0.9rem;
+}
+
+.share-modal-close {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 30px;
+  height: 30px;
+  border: 1px solid rgba(255, 255, 255, 0.15);
+  border-radius: 6px;
+  background: rgba(255, 255, 255, 0.04);
+  color: #ffffff;
+  cursor: pointer;
+}
+
+.share-modal-close:hover {
+  background: rgba(255, 255, 255, 0.1);
+}
+
+.share-modal-search-wrap {
+  position: relative;
+  padding: 12px 16px;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.15);
+}
+
+.share-modal-search-icon {
+  position: absolute;
+  top: 50%;
+  left: 28px;
+  transform: translateY(-50%);
+  color: rgba(255, 255, 255, 0.7);
+  pointer-events: none;
+}
+
+.share-modal-search-input {
+  width: 100%;
+  box-sizing: border-box;
+  border: 1px solid rgba(255, 255, 255, 0.24);
+  border-radius: 6px;
+  background: rgba(0, 0, 0, 0.18);
+  color: #ffffff;
+  font-size: 0.95rem;
+  line-height: 1.4;
+  padding: 9px 10px 9px 34px;
+  outline: none;
+}
+
+.share-modal-search-input::placeholder {
+  color: rgba(255, 255, 255, 0.6);
+}
+
+.share-modal-search-input:focus {
+  border-color: var(--primary-green);
+  box-shadow: 0 0 0 3px rgba(48, 164, 108, 0.25);
+}
+
+.share-modal-feedback,
+.share-modal-error {
+  margin: 12px 16px 0;
+  padding: 10px 12px;
+  border-radius: 6px;
+  font-size: 0.9rem;
+}
+
+.share-modal-feedback {
+  border: 1px solid rgba(48, 164, 108, 0.75);
+  background: rgba(48, 164, 108, 0.18);
+  color: #d2ffea;
+}
+
+.share-modal-error {
+  border: 1px solid rgba(255, 118, 101, 0.8);
+  background: rgba(255, 118, 101, 0.16);
+  color: #ffd8d3;
+}
+
+.share-modal-results {
+  max-height: 360px;
+  overflow: auto;
+}
+
+.share-modal-empty {
+  padding: 18px 16px;
+  color: rgba(255, 255, 255, 0.78);
+  font-size: 0.95rem;
+}
+
+.share-modal-list {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.share-modal-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 12px 16px;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.12);
+}
+
+.share-modal-user {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  min-width: 0;
+}
+
+.share-modal-avatar {
+  width: 30px;
+  height: 30px;
+  border-radius: 50%;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: 700;
+  font-size: 0.9rem;
+  background: var(--primary-green);
+  color: #ffffff;
+  flex-shrink: 0;
+}
+
+.share-modal-user-text {
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.share-modal-username {
+  font-weight: 600;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.share-modal-email {
+  color: rgba(255, 255, 255, 0.7);
+  font-size: 0.85rem;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.share-modal-add-btn {
+  border: 1px solid rgba(255, 255, 255, 0.16);
+  border-radius: 6px;
+  background: var(--primary-green);
+  color: #ffffff;
+  font-size: 0.85rem;
+  font-weight: 600;
+  padding: 6px 12px;
+  cursor: pointer;
+  transition: opacity 0.15s ease;
+}
+
+.share-modal-add-btn:hover:not(:disabled) {
+  opacity: 0.9;
+}
+
+.share-modal-add-btn:disabled {
+  cursor: not-allowed;
+  opacity: 0.7;
+}
+
+.share-modal-footer {
+  display: flex;
+  justify-content: flex-end;
+  padding: 12px 16px;
+  border-top: 1px solid rgba(255, 255, 255, 0.15);
+}
+
+.share-modal-done-btn {
+  border: 1px solid rgba(255, 255, 255, 0.25);
+  border-radius: 6px;
+  background: rgba(255, 255, 255, 0.08);
+  color: #ffffff;
+  font-size: 0.9rem;
+  font-weight: 600;
+  padding: 7px 14px;
+  cursor: pointer;
+}
+
+.share-modal-done-btn:hover {
+  background: rgba(255, 255, 255, 0.14);
+}
+
+@media (max-width: 700px) {
+  .share-modal-overlay {
+    padding-top: 20px;
+  }
+}

--- a/frontend/src/utils/api.ts
+++ b/frontend/src/utils/api.ts
@@ -23,6 +23,7 @@ import type {
   AuthResetPasswordRequest,
   DeletePodDataRequest,
   DeletePodDataResponse,
+  GetPodOwnersResponse,
   MessageResponse,
   PodDataResponse,
   GetPodLocationsRequest,
@@ -614,6 +615,18 @@ export async function addPodOwner(
     method: "POST",
     path: `/pods/${encodeURIComponent(podId)}/owners`,
     body: payload,
+    auth: true,
+    signal,
+  });
+}
+
+export async function getPodOwners(
+  podId: string,
+  signal?: AbortSignal,
+): Promise<GetPodOwnersResponse> {
+  return await request<GetPodOwnersResponse>({
+    method: "GET",
+    path: `/pods/${encodeURIComponent(podId)}/owners`,
     auth: true,
     signal,
   });

--- a/frontend/src/utils/api.ts
+++ b/frontend/src/utils/api.ts
@@ -7,6 +7,8 @@
  */
 
 import type {
+  AddPodOwnerRequest,
+  AddPodOwnerResponse,
   AdminDeactivateUserRequest,
   AdminGenerateInvitationTokenResponse,
   AdminRevokeInvitationTokenRequest,
@@ -552,7 +554,7 @@ export async function getPodLocations(
     method: "GET",
     path: "/pods/locations",
     query: params,
-    auth: false,
+    auth: true,
     signal,
   });
 }
@@ -583,6 +585,22 @@ export async function deletePodData(payload: DeletePodDataRequest, signal?: Abor
   return await request<DeletePodDataResponse>({
     method: "DELETE",
     path: "/pods/delete-pod-data",
+    body: payload,
+    auth: true,
+    signal,
+  });
+}
+
+// TODO:
+
+export async function addPodOwner(
+  podId: string,
+  payload: AddPodOwnerRequest,
+  signal?: AbortSignal,
+): Promise<AddPodOwnerResponse> {
+  return await request<AddPodOwnerResponse>({
+    method: "POST",
+    path: `/pods/${encodeURIComponent(podId)}/owners`,
     body: payload,
     auth: true,
     signal,

--- a/frontend/src/utils/api.ts
+++ b/frontend/src/utils/api.ts
@@ -29,6 +29,7 @@ import type {
   PodLocationsResponse,
   RegisterPodRequest,
   RequestEmailChangeRequest,
+  SearchPodOwnerCandidatesResponse,
   UnregisterPodRequest,
   UpdatePasswordRequest,
   UpdatePodRequest,
@@ -591,7 +592,18 @@ export async function deletePodData(payload: DeletePodDataRequest, signal?: Abor
   });
 }
 
-// TODO:
+export async function searchUsers(
+  username: string,
+  signal?: AbortSignal,
+): Promise<SearchPodOwnerCandidatesResponse> {
+  return await request<SearchPodOwnerCandidatesResponse>({
+    method: "GET",
+    path: "/users/search",
+    query: { username, limit: 10 },
+    auth: true,
+    signal,
+  });
+}
 
 export async function addPodOwner(
   podId: string,

--- a/frontend/src/utils/apiTypes.ts
+++ b/frontend/src/utils/apiTypes.ts
@@ -175,3 +175,7 @@ export type AddPodOwnerResponse = MessageResponse & {
   podId: string;
   userId: string;
 };
+
+export type GetPodOwnersResponse = {
+  owners: PodOwnerCandidate[];
+};

--- a/frontend/src/utils/apiTypes.ts
+++ b/frontend/src/utils/apiTypes.ts
@@ -43,6 +43,7 @@ export type PodLocation = {
   longitude: number;
   visibility: "public" | "private";
   lastUpdated?: string;
+  isOwner?: boolean;
 };
 
 export type PodLocationsResponse = { pods: PodLocation[] };
@@ -71,6 +72,12 @@ export type PodDataResponse = {
   visibility: "public" | "private";
   lastUpdated: string;
   data: PodDataEntry[];
+  viewer?: {
+    isAuthenticated: boolean;
+    isOwner: boolean;
+    isAdmin: boolean;
+    canManagePod: boolean;
+  };
 };
 
 // ----------------------------
@@ -152,3 +159,21 @@ export type UploadPodDataResponse = MessageResponse & { podDataId: string };
 export type DeletePodDataRequest = { podDataId: string };
 export type DeletePodDataResponse = MessageResponse & { podDataId: string };
 
+export type PodOwnerCandidate = {
+  id: string;
+  username: string;
+  email: string | null;
+};
+
+export type SearchPodOwnerCandidatesResponse = {
+  users: PodOwnerCandidate[];
+};
+
+export type AddPodOwnerRequest = {
+  userId: string;
+};
+
+export type AddPodOwnerResponse = MessageResponse & {
+  podId: string;
+  userId: string;
+};

--- a/frontend/src/utils/apiTypes.ts
+++ b/frontend/src/utils/apiTypes.ts
@@ -66,10 +66,10 @@ export type PodDataEntry = {
 export type PodDataResponse = {
   id: string;
   nickname: string;
-  latitude: number;
-  longitude: number;
+  latitude: number | null;
+  longitude: number | null;
   visibility: "public" | "private";
-  lastUpdated: string;
+  lastUpdated: string | null;
   data: PodDataEntry[];
   viewer?: {
     isAuthenticated: boolean;

--- a/frontend/src/utils/apiTypes.ts
+++ b/frontend/src/utils/apiTypes.ts
@@ -52,14 +52,13 @@ export type PodDataEntry = {
   id: string;
   timestamp: string;
   data: {
-    sensor_data_id: string;
-    pod_data_id: string;
     sensor_type: string;
     reading_value: number;
     reading_units: string;
-    reading_timestamp: string;
-    raw_data: Record<string, unknown>; // JSONB raw sensor payload
-    created_at: string;
+    location: {
+      latitude: number;
+      longitude: number;
+    };
   };
   visibility: "public" | "private";
 };
@@ -160,9 +159,8 @@ export type DeletePodDataRequest = { podDataId: string };
 export type DeletePodDataResponse = MessageResponse & { podDataId: string };
 
 export type PodOwnerCandidate = {
-  id: string;
+  id: number;
   username: string;
-  email: string | null;
 };
 
 export type SearchPodOwnerCandidatesResponse = {
@@ -170,7 +168,7 @@ export type SearchPodOwnerCandidatesResponse = {
 };
 
 export type AddPodOwnerRequest = {
-  userId: string;
+  userId: number;
 };
 
 export type AddPodOwnerResponse = MessageResponse & {


### PR DESCRIPTION
# Summary
Adds the ability for pod owners to share their pods with other users as co-owners. This includes a new backend API route, frontend share modal with user search, and visual differentiation of owned pods on the map.
# Changes
## Backend
- New route `POST /pods/:id/owners` — Allows authenticated pod owners (or admins) to add another user as a co-owner of a pod. Returns 403 if not authorized, 404 if pod/user not found, 409 if user is already an owner.
- `GET /pods/locations` — Now returns an isOwner flag per pod when the user is authenticated.
- `GET /pods/:id/data` — Response restructured to include a viewer object with `isAuthenticated`, `isOwner`, `isAdmin`, and `canManagePod` flags.
- `GET /users/search` — Now excludes admins and the requesting user from search results.
- Tests — Added tests for `isOwner` on pod locations and full coverage for the new `POST /pods/:id/owners` route (success, 403, 404, 409 cases).
## Frontend
- `SharePodModal` — New modal component with debounced user search, allowing pod owners to search for and add collaborators.
- Pod page — Share button shown to pod owners, launching the share modal. Upload button visibility now driven by the `viewer.canManagePod` flag from the API.
- Map markers — Owned pods are visually distinguished with a green marker style. A "Your Pod" entry is added to the map legend.
- Login refresh — Map pod markers refresh on login via a custom `eva.login` event so ownership status is reflected immediately.
- API utilities — Added searchUsers and addPodOwner functions. getPodLocations now sends auth credentials.
- Type definitions — Added `PodOwnerCandidate`, `SearchPodOwnerCandidatesResponse`, `AddPodOwnerRequest`, `AddPodOwnerResponse`. Updated `PodLocation` and `PodDataResponse` types to match new API shapes.